### PR TITLE
Better reporting of unhandled exceptions (fixes #132)

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -88,6 +88,17 @@ class MerginProjectItem(QgsDataItem):
         msg = "<font color=red>Security token has been expired, failed to renew. Check your username and password </font>"
         QMessageBox.critical(None, 'Login failed', msg, QMessageBox.Close)
 
+    def _unhandled_exception_message(self, error_details, dialog_title, error_text):
+        msg = error_text + "<p>This should not happen, " \
+              "<a href=\"https://github.com/lutraconsulting/qgis-mergin-plugin/issues\">" \
+              "please report the problem</a>."
+        box = QMessageBox()
+        box.setIcon(QMessageBox.Critical)
+        box.setWindowTitle(dialog_title)
+        box.setText(msg)
+        box.setDetailedText(error_details)
+        box.exec_()
+
     def download(self):
         settings = QSettings()
 
@@ -120,12 +131,9 @@ class MerginProjectItem(QgsDataItem):
             elif isinstance(dlg.exception, LoginError):
                 self._login_error_message(dlg.exception)
             else:
-                msg = "Failed to download project {} due to an unhandled exception.\n\n" \
-                      "This should not happen, please report the problem here:\n" \
-                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
-                      .format(self.project_name)
-                msg += dlg.exception_details()
-                QMessageBox.critical(None, 'Project download', msg, QMessageBox.Close)
+                self._unhandled_exception_message(
+                    dlg.exception_details(), "Project download",
+                    f"Failed to download project {self.project_name} due to an unhandled exception.")
             return
 
         if not dlg.is_complete:
@@ -282,12 +290,9 @@ class MerginProjectItem(QgsDataItem):
             elif isinstance(dlg.exception, ClientError):
                 QMessageBox.critical(self, "Project sync", "Client error: " + str(dlg.exception))
             else:
-                msg = "Failed to sync project {} due to an unhandled exception.\n\n" \
-                      "This should not happen, please report the problem here:\n" \
-                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
-                      .format(self.project_name)
-                msg += dlg.exception_details()
-                QMessageBox.critical(None, 'Project sync', msg, QMessageBox.Close)
+                self._unhandled_exception_message(
+                    dlg.exception_details(), "Project sync",
+                    f"Failed to sync project {self.project_name} due to an unhandled exception.")
             return
 
         if dlg.pull_conflicts:
@@ -322,12 +327,9 @@ class MerginProjectItem(QgsDataItem):
             elif isinstance(dlg.exception, ClientError):
                 QMessageBox.critical(None, "Project sync", "Client error: " + str(dlg.exception))
             else:
-                msg = "Failed to sync project {} due to an unhandled exception.\n\n" \
-                      "This should not happen, please report the problem here:\n" \
-                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
-                      .format(self.project_name)
-                msg += dlg.exception_details()
-                QMessageBox.critical(None, 'Project sync', msg, QMessageBox.Close)
+                self._unhandled_exception_message(
+                    dlg.exception_details(), "Project sync",
+                    f"Failed to sync project {self.project_name} due to an unhandled exception.")
             return
 
         if dlg.is_complete:
@@ -539,12 +541,9 @@ class MerginRootItem(QgsDataCollectionItem):
             elif isinstance(dlg.exception, ClientError):
                 QMessageBox.critical(None, "Project sync", "Client error: " + str(dlg.exception))
             else:
-                msg = "Failed to sync project {} due to an unhandled exception.\n\n" \
-                      "This should not happen, please report the problem here:\n" \
-                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
-                      .format(project_name)
-                msg += dlg.exception_details()
-                QMessageBox.critical(None, 'Project sync', msg, QMessageBox.Close)
+                self._unhandled_exception_message(
+                    dlg.exception_details(), "Project sync",
+                    f"Failed to sync project {project_name} due to an unhandled exception.")
             return
 
         if not dlg.is_complete:

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -120,8 +120,11 @@ class MerginProjectItem(QgsDataItem):
             elif isinstance(dlg.exception, LoginError):
                 self._login_error_message(dlg.exception)
             else:
-                msg = "Failed to download your project {}.\n" \
-                      "{}".format(self.project_name, str(dlg.exception))
+                msg = "Failed to download project {} due to an unhandled exception.\n\n" \
+                      "This should not happen, please report the problem here:\n" \
+                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
+                      .format(self.project_name)
+                msg += dlg.exception_details()
                 QMessageBox.critical(None, 'Project download', msg, QMessageBox.Close)
             return
 
@@ -279,8 +282,11 @@ class MerginProjectItem(QgsDataItem):
             elif isinstance(dlg.exception, ClientError):
                 QMessageBox.critical(self, "Project sync", "Client error: " + str(dlg.exception))
             else:
-                # TODO: this should not happen normally - "known" exceptions should be recognized
-                msg = "Failed to download changes!\n\n{}".format(str(dlg.exception))
+                msg = "Failed to sync project {} due to an unhandled exception.\n\n" \
+                      "This should not happen, please report the problem here:\n" \
+                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
+                      .format(self.project_name)
+                msg += dlg.exception_details()
                 QMessageBox.critical(None, 'Project sync', msg, QMessageBox.Close)
             return
 
@@ -316,8 +322,11 @@ class MerginProjectItem(QgsDataItem):
             elif isinstance(dlg.exception, ClientError):
                 QMessageBox.critical(None, "Project sync", "Client error: " + str(dlg.exception))
             else:
-                # TODO: this should not happen normally - "known" exceptions should be recognized
-                msg = "Failed to upload changes!\n\n{}".format(str(dlg.exception))
+                msg = "Failed to sync project {} due to an unhandled exception.\n\n" \
+                      "This should not happen, please report the problem here:\n" \
+                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
+                      .format(self.project_name)
+                msg += dlg.exception_details()
                 QMessageBox.critical(None, 'Project sync', msg, QMessageBox.Close)
             return
 
@@ -530,8 +539,11 @@ class MerginRootItem(QgsDataCollectionItem):
             elif isinstance(dlg.exception, ClientError):
                 QMessageBox.critical(None, "Project sync", "Client error: " + str(dlg.exception))
             else:
-                # TODO: this should not happen normally - "known" exceptions should be recognized
-                msg = "Failed to upload changes!\n\n{}".format(str(dlg.exception))
+                msg = "Failed to sync project {} due to an unhandled exception.\n\n" \
+                      "This should not happen, please report the problem here:\n" \
+                      "https://github.com/lutraconsulting/qgis-mergin-plugin/issues/new\n\n" \
+                      .format(project_name)
+                msg += dlg.exception_details()
                 QMessageBox.critical(None, 'Project sync', msg, QMessageBox.Close)
             return
 

--- a/Mergin/sync_dialog.py
+++ b/Mergin/sync_dialog.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import traceback
 from PyQt5.QtWidgets import QDialog, QApplication
 from PyQt5 import uic
 from PyQt5.QtCore import Qt, QTimer
@@ -29,6 +31,8 @@ class SyncDialog(QDialog):
         self.pull_conflicts = None  # what is returned from pull_project_finalize()
 
         self.exception = None
+        self.exception_type = None
+        self.exception_tb = None
         self.is_complete = False
         self.job = None
 
@@ -65,10 +69,16 @@ class SyncDialog(QDialog):
         self.target_dir = None
         self.project_name = None
         self.job = None
-        self.exception = exception
+        if exception is not None:
+            # assuming this is called from exception handler, traceback of the exception
+            self.exception_type, self.exception, self.exception_tb = sys.exc_info()
         self.is_complete = success
         if close:
             self.close()
+
+    def exception_details(self):
+        """ If an exception was set, this returns a formatted string with a traceback """
+        return '\n'.join(traceback.format_exception(self.exception_type, self.exception, self.exception_tb))
 
     #######################################################
 


### PR DESCRIPTION
Mergin plugin will report full traceback, not just exception converted to string, which does not say much (see #132)

Note: this does not fix the underlying issue of #132, only improves error reporting.