### PR TITLE
Fixed Python deprecation warnings about implicit float/int conversions

### DIFF
--- a/Mergin/sync_dialog.py
+++ b/Mergin/sync_dialog.py
@@ -111,7 +111,7 @@ class SyncDialog(QDialog):
         assert self.job  # if there was no error thrown, we should have a job
 
         # use kilobytes as a unit so we do not need to worry about int overflow with projects of few GB size
-        self.progress.setMaximum(self.job.total_size / 1024)
+        self.progress.setMaximum(int(self.job.total_size / 1024))
         self.progress.setValue(0)
 
         self.timer.start()
@@ -120,7 +120,7 @@ class SyncDialog(QDialog):
 
     def download_timer_tick(self):
 
-        self.progress.setValue(self.job.transferred_size / 1024)
+        self.progress.setValue(int(self.job.transferred_size / 1024))
 
         try:
             is_running = download_project_is_running(self.job)
@@ -195,7 +195,7 @@ class SyncDialog(QDialog):
             return
 
         # use kilobytes as a unit so we do not need to worry about int overflow with projects of few GB size
-        self.progress.setMaximum(self.job.total_size / 1024)
+        self.progress.setMaximum(int(self.job.total_size / 1024))
         self.progress.setValue(0)
 
         self.timer.start()
@@ -204,7 +204,7 @@ class SyncDialog(QDialog):
 
     def push_timer_tick(self):
 
-        self.progress.setValue(self.job.transferred_size / 1024)
+        self.progress.setValue(int(self.job.transferred_size / 1024))
 
         try:
             is_running = push_project_is_running(self.job)
@@ -279,7 +279,7 @@ class SyncDialog(QDialog):
             return
 
         # use kilobytes as a unit so we do not need to worry about int overflow with projects of few GB size
-        self.progress.setMaximum(self.job.total_size / 1024)
+        self.progress.setMaximum(int(self.job.total_size / 1024))
         self.progress.setValue(0)
 
         self.timer.start()
@@ -288,7 +288,7 @@ class SyncDialog(QDialog):
 
     def pull_timer_tick(self):
 
-        self.progress.setValue(self.job.transferred_size / 1024)
+        self.progress.setValue(int(self.job.transferred_size / 1024))
 
         try:
             is_running = pull_project_is_running(self.job)


### PR DESCRIPTION
Closes https://github.com/lutraconsulting/mergin-py-client/issues/88 - it was reported for Mergin Python client but actually fixed in the Mergin plugin code.