### PR TITLE
Bumped minimum QGIS version for the plugin to 3.10

### DIFF
--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -1,7 +1,7 @@
 ; the next section is mandatory
 [general]
 name=Mergin
-qgisMinimumVersion=3.4
+qgisMinimumVersion=3.10
 qgisMaximumVersion=3.99
 description=Handle Mergin projects
 version=2021.2


### PR DESCRIPTION
Closes #230

We use `QgsMapLayerType` enum which is available only for QGIS 3.10+