### PR TITLE
Add global Mergin client log to user-submitted logs

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -52,6 +52,9 @@ from .utils import (
 
 from .mergin.merginproject import MerginProject
 
+MERGIN_CLIENT_LOG = os.path.join(QgsApplication.qgisSettingsDirPath(), "mergin-client-log.txt")
+os.environ['MERGIN_CLIENT_LOG'] = MERGIN_CLIENT_LOG
+
 
 class MerginPlugin:
     def __init__(self, iface):

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -245,7 +245,7 @@ def send_logs(username, logfile):
     global_logs = b""
     if global_log_file and os.path.exists(global_log_file):
         with open(global_log_file, 'rb') as f:
-            if os.path.getsize(logfile) > 512 * 1024:
+            if os.path.getsize(logfile) > 100 * 1024:
                 f.seek(-100 * 1024, os.SEEK_END)
             global_logs = f.read() + b"\n--------------------------------\n\n"
 

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -223,6 +223,8 @@ def send_logs(username, logfile):
     mergin_url, _, _ = get_mergin_auth()
     system = platform.system().lower()
     version = plugin_version()
+    # also read global mergin client log
+    global_log_file = os.environ.get('MERGIN_CLIENT_LOG', None)
 
     params = {
         "app": "plugin-{}-{}".format(system, version),
@@ -231,7 +233,7 @@ def send_logs(username, logfile):
     url = MERGIN_LOGS_URL + "?" + urllib.parse.urlencode(params)
     header = {"content-type": "text/plain"}
 
-    meta = "Plugin: {} \nQGIS: {} \nSystem: {} \nMergin URL: {} \nMergin user: {} \n--------------------------------\n"\
+    meta = "Plugin: {} \nQGIS: {} \nSystem: {} \nMergin URL: {} \nMergin user: {} \n--------------------------------\n\n"\
         .format(
             version,
             get_qgis_version_str(),
@@ -240,12 +242,17 @@ def send_logs(username, logfile):
             username
         )
 
+    global_logs = "".encode()
+    if global_log_file:
+        with open(global_log_file, 'rb') as f:
+            global_logs = f.read() + "\n--------------------------------\n\n".encode()
+
     with open(logfile, 'rb') as f:
         if os.path.getsize(logfile) > 512 * 1024:
             f.seek(-512 * 1024, os.SEEK_END)
         logs = f.read()
 
-    payload = meta.encode() + logs
+    payload = meta.encode() + global_logs + logs
     try:
         req = urllib.request.Request(url, data=payload, headers=header)
         resp = urllib.request.urlopen(req)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -242,10 +242,12 @@ def send_logs(username, logfile):
             username
         )
 
-    global_logs = "".encode()
-    if global_log_file:
+    global_logs = b""
+    if global_log_file and os.path.exists(global_log_file):
         with open(global_log_file, 'rb') as f:
-            global_logs = f.read() + "\n--------------------------------\n\n".encode()
+            if os.path.getsize(logfile) > 512 * 1024:
+                f.seek(-100 * 1024, os.SEEK_END)
+            global_logs = f.read() + b"\n--------------------------------\n\n"
 
     with open(logfile, 'rb') as f:
         if os.path.getsize(logfile) > 512 * 1024:


### PR DESCRIPTION
It is a part of a fix for #186 - https://github.com/lutraconsulting/mergin-py-client/pull/91
