### PR TITLE
Fix fetching more items in Explore group

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -672,7 +672,7 @@ class MerginGroupItem(QgsDataCollectionItem):
             except RuntimeError:
                 pass
             self.fetch_more_item = None
-        fetched_count = self.rowCount() + len(self.projects)
+        fetched_count = len(self.projects)
         if fetched_count < self.total_projects_count:
             self.fetch_more_item = FetchMoreItem(self)
             self.fetch_more_item.setState(QgsDataItem.Populated)


### PR DESCRIPTION
This fixes fetching more items in the Explore group. There was invalid number of already fetched projects calculated and the Fetch more browser item was hidden well before a user fetch all the projects from the group.
We no longer depopulate the group after a page of projects is fetched, so we need to calculate fetched projects number in a different way.