### PR TITLE
Fixed remote project item - opening a downloaded project.

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -357,6 +357,9 @@ class MerginRemoteProjectItem(QgsDataItem):
             self.open_project()
         self.parent().reload()
 
+    def open_project(self):
+        self.project_manager.open_project(self.path)
+
     def clone_remote_project(self):
         user_info = self.mc.user_info()
         dlg = CloneProjectDialog(username=user_info["username"], user_organisations=user_info.get("organisations", []))


### PR DESCRIPTION
Remote project browser items actually need the open_project() method - once the project is downloaded it may be also open - and it should be ideally done before refreshing the group item, so before the remote project item would turn into a local one.