### PR TITLE
ci for packaging (part-1 no fixes for libs rpaths)

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,162 @@
+name: Build Mergin Plugin Packages
+env:
+  MERGIN_CLIENT_VER: "0.6.0"
+  GEODIFF_VER: "1.0.0"
+  PYTHON_VER: "36"
+
+on: [push]
+jobs:
+  build_linux_binary:
+    name: Extract geodiff binary linux
+    runs-on: ubuntu-latest
+    env:
+      PY_PLATFORM: "manylinux2014_x86_64"
+    steps:
+      - uses: actions/setup-python@v2
+        name: Install Python
+
+      - name: Download pygeodiff binaries
+        run: |
+          pip3 download --only-binary=:all: \
+            --no-deps --platform ${PY_PLATFORM} \
+            --python-version ${PYTHON_VER} \
+            --implementation cp \
+            --abi cp${PYTHON_VER}m pygeodiff==${GEODIFF_VER}
+          unzip -o pygeodiff-$GEODIFF_VER-cp${PYTHON_VER}-cp${PYTHON_VER}m-${PY_PLATFORM}.whl -d tmp || true
+          mkdir pygeodiff-binaries
+          cp tmp/pygeodiff/libpygeodiff-${GEODIFF_VER}-python.so ./pygeodiff-binaries/
+
+      - name: Patching pygeodiff binaries
+        run: |
+          echo "no-op !! Here is the place to patch linkage !!"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./pygeodiff-binaries/*.so
+
+  build_windows_binaries:
+    name: Extract geodiff binary windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-python@v2
+        name: Install Python
+
+      - name: Install deps
+        run: |
+          choco install unzip
+
+      - name: Download pygeodiff 32 binaries
+        run: |
+          pip3 download --only-binary=:all: --no-deps --platform "win32" --python-version $env:PYTHON_VER pygeodiff==$env:GEODIFF_VER
+          unzip -o pygeodiff-$env:GEODIFF_VER-cp$env:PYTHON_VER-cp$env:PYTHON_VER'm'-win32.whl -d tmp32
+          mkdir pygeodiff-binaries
+          copy tmp32\pygeodiff\*.pyd pygeodiff-binaries\
+
+      - name: Download pygeodiff 64 binaries
+        run: |
+          pip3 download --only-binary=:all: --no-deps --platform "win_amd64" --python-version $env:PYTHON_VER pygeodiff==$env:GEODIFF_VER
+          unzip -o pygeodiff-$env:GEODIFF_VER-cp$env:PYTHON_VER-cp$env:PYTHON_VER'm'-win_amd64.whl -d tmp64
+          copy tmp64\pygeodiff\*.pyd pygeodiff-binaries\
+
+      - name: Patching pygeodiff binaries
+        run: |
+          echo "no-op !! Here is the place to patch linkage !!"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./pygeodiff-binaries/*.pyd
+
+  build_macos_binary:
+    name: Extract geodiff binary macos
+    runs-on: macos-latest
+    env:
+      PY_PLATFORM: "macosx_10_9_x86_64"
+    steps:
+      - uses: actions/setup-python@v2
+        name: Install Python
+
+      - name: Install deps
+        run: |
+          brew install unzip
+
+      - name: Download pygeodiff binaries
+        run: |
+          pip3 download --only-binary=:all: --no-deps --platform ${PY_PLATFORM} --python-version ${PYTHON_VER} --implementation cp --abi cp${PYTHON_VER}m pygeodiff==$GEODIFF_VER
+          unzip -o pygeodiff-$GEODIFF_VER-cp${PYTHON_VER}-cp${PYTHON_VER}m-${PY_PLATFORM}.whl -d tmp
+          mkdir pygeodiff-binaries
+          cp tmp/pygeodiff/*.dylib ./pygeodiff-binaries/
+
+      - name: Patching pygeodiff binaries
+        run: |
+          echo "no-op !! Here is the place to patch linkage !!"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./pygeodiff-binaries/*.dylib
+
+  create_mergin_plugin_package:
+    needs: [build_windows_binaries, build_linux_binary, build_macos_binary]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: lutraconsulting/mergin-py-client
+          ref: ${{ env.MERGIN_CLIENT_VER }}
+          path: mergin-py-client
+
+      - name: prepare py-client dependencies
+        run: |
+          cd mergin-py-client
+          python3 setup.py sdist bdist_wheel
+          mkdir -p mergin/deps
+          # without __init__.py the deps dir may get recognized as "namespace package" in python
+          # and it can break qgis plugin unloading mechanism - see #126
+          touch mergin/deps/__init__.py
+          pip3 wheel -r mergin_client.egg-info/requires.txt -w mergin/deps
+          # special care for pygeodiff
+          unzip mergin/deps/pygeodiff-*.whl -d mergin/deps
+          # remove unncesessary files
+          rm -rf mergin/deps/*.dist-info
+          rm -rf mergin/deps/*.data
+          rm -rf mergin/deps/pygeodiff.libs
+          rm -rf mergin/deps/pygeodiff-*.whl
+
+      - name: check geodiff version in sync with mergin-py-client
+        run: |
+          GEODIFF_VER_FROM_CLIENT="$(geodiff="$(cat mergin-py-client/mergin_client.egg-info/requires.txt | grep pygeodiff)";echo ${geodiff#pygeodiff==})"
+          if [ "$GEODIFF_VER" != "$GEODIFF_VER_FROM_CLIENT" ]; then
+            echo "geodiff version defined in mergin-py-client requires.txt $GEODIFF_VER_FROM_CLIENT does not equal $GEODIFF_VER from the workpackage file"
+            exit 1; # or just warning??
+          fi
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: pygeodiff-binaries
+
+      - name: include pygeodiff deps
+        run: |
+          cp pygeodiff-binaries/* mergin-py-client/mergin/deps/pygeodiff
+
+      - uses: actions/checkout@v2
+        with:
+          path: qgis-mergin-plugin
+
+      - name: create package
+        run: |
+          cp -r mergin-py-client/mergin qgis-mergin-plugin/Mergin
+          cd qgis-mergin-plugin/
+          find .
+          zip -r mergin.zip Mergin/ -x Mergin/__pycache__/\*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: qgis-mergin-plugin/mergin.zip
+
+      - name: upload asset on tagged release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: qgis-mergin-plugin/mergin.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Mergin QGIS plugin
 <img src="Mergin/images/icon.png">
 
+[![.github/workflows/packages.yml](https://github.com/lutraconsulting/qgis-mergin-plugin/actions/workflows/packages.yml/badge.svg)](https://github.com/lutraconsulting/qgis-mergin-plugin/actions/workflows/packages.yml)
+
 ## Quick start
 QGIS plugin aims to simplify handling of [Mergin](https://public.cloudmergin.com/) projects.
 


### PR DESCRIPTION
Add CI support to generate Mergin QGIS Plugin. The pygeodiff libraries are included, but NOT patched to use QGIS sqlite library, so most probably it plugin will not load in QGIS