### PR TITLE
[CI] Packaging for linux

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
-          echo "no-op !! Here is the place to patch linkage !!"
+          patchelf --replace-needed libsqlite3-d9e27dab.so.0.8.6 libsqlite3.so.0.8.6 ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so \
+          patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           SQLITE_LINE=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3)
           echo ${SQLITE_LINE}
-          echo ${SQLITE_LINE} | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/
+          echo ${SQLITE_LINE} | sed -E "s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/"
           SQLITE_LIB=libsqlite3-d9e27dab.so.0.8.6
           patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,9 +28,9 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
-          #SQLITE_LIB="$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3 | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/)"
           SQLITE_LINE=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3)
           echo ${SQLITE_LINE}
+          echo ${SQLITE_LINE} | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/
           SQLITE_LIB=libsqlite3-d9e27dab.so.0.8.6
           patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,7 +28,10 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
-          SQLITE_LIB="$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3 | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/)"
+          #SQLITE_LIB="$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3 | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/)"
+          SQLITE_LINE=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3)
+          echo ${SQLITE_LINE}
+          SQLITE_LIB=libsqlite3-d9e27dab.so.0.8.6
           patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
+          sudo apt-get install patchelf
           patchelf --replace-needed libsqlite3-d9e27dab.so.0.8.6 libsqlite3.so.0.8.6 ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so \
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,12 +28,9 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
+          # get exact name of the linked library (e.g. libsqlite3-d9e27dab.so.0.8.6)
           SQLITE_LINE=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3)
-          echo ${SQLITE_LINE}
-          echo ${SQLITE_LINE} | sed -E "s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/"
-          SQ=$(echo ${SQLITE_LINE} | sed -E "s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/")
-          echo ${SQ}
-          SQLITE_LIB=libsqlite3-d9e27dab.so.0.8.6
+          SQLITE_LIB=$(echo ${SQLITE_LINE} | sed -E "s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/")
           patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,8 +28,7 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
-          sudo apt-get install patchelf
-          patchelf --replace-needed libsqlite3-d9e27dab.so.0.8.6 libsqlite3.so.0.8.6 ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so \
+          patchelf --replace-needed libsqlite3-d9e27dab.so.0.8.6 libsqlite3.so.0.8.6 ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,9 +28,8 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
-          # extract the exact libname (e.g. libsqlite3-d9e27dab.so.0.8.6)
-          SQLITE_LIB=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3 | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/)
-          patchelf --replace-needed $SQLITE_LIB libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
+          SQLITE_LIB="$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3 | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/)"
+          patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -31,6 +31,8 @@ jobs:
           SQLITE_LINE=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3)
           echo ${SQLITE_LINE}
           echo ${SQLITE_LINE} | sed -E "s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/"
+          SQ=$(echo ${SQLITE_LINE} | sed -E "s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/")
+          echo ${SQ}
           SQLITE_LIB=libsqlite3-d9e27dab.so.0.8.6
           patchelf --replace-needed ${SQLITE_LIB} libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
           patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,8 +28,10 @@ jobs:
 
       - name: Patching pygeodiff binaries
         run: |
-          patchelf --replace-needed libsqlite3-d9e27dab.so.0.8.6 libsqlite3.so.0.8.6 ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so
-          patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-1.0.0-python.so
+          # extract the exact libname (e.g. libsqlite3-d9e27dab.so.0.8.6)
+          SQLITE_LIB=$(ldd ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so | grep libsqlite3 | sed -E s/.*(libsqlite3-[a-z0-9]+.so[\\.0-9]+).*/\\1/)
+          patchelf --replace-needed $SQLITE_LIB libsqlite3.so ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
+          patchelf --remove-rpath ./pygeodiff-binaries/libpygeodiff-${GEODIFF_VER}-python.so
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Remove the internal sqlite3 dependency from pygeodiff on linux (sqlite3 will be used from qgis install)

Refs #261 