### PR TITLE
Packaging fixes

### DIFF
--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -1,7 +1,7 @@
 ; the next section is mandatory
 [general]
 name=Mergin
-qgisMinimumVersion=3.16
+qgisMinimumVersion=3.10
 qgisMaximumVersion=3.99
 description=Handle Mergin projects
 version=2021.4.2

--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -1,7 +1,7 @@
 ; the next section is mandatory
 [general]
 name=Mergin
-qgisMinimumVersion=3.10
+qgisMinimumVersion=3.16
 qgisMaximumVersion=3.99
 description=Handle Mergin projects
 version=2021.4.2


### PR DESCRIPTION
Fixes #273 - do not rewrite GeoTiffs 
Fixes #277 - added a check for tree node layers validity - invalid layers are kept as is by default - they might be valid layers in a specific environment only.