### PR TITLE
Add attention banner

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -251,7 +251,9 @@ class MerginPlugin:
             if requires_action:
                 iface.messageBar().pushMessage(
                     "Mergin",
-                    f"Your attention is required.&nbsp;Please visit the <a href={self.mc.url}>Mergin dashboard</a>",
+                    "Your attention is required.&nbsp;Please visit the "
+                    f"<a href='{self.mc.url}/dashboard?utm_source=plugin&utm_medium=attention-required'>"
+                    "Mergin dashboard</a>",
                     level=Qgis.Critical
                 )
 


### PR DESCRIPTION
**PR REQUIRES NEW VERSION OF MERGIN_PY_CLIENT!**

This PR adds action required banner to plugin. 

`/v1/user/service` endpoint is used to find out if the banner should be visible based on `action_required` key. API call has been added to mergin py client.

Banner is shown inside Qgis message bar as error message without timer. It is shown each time user logs in or starts QGIS while being logged in automatically.  

Screenshots:

![image (1)](https://user-images.githubusercontent.com/22449698/141298397-e5c615fd-a95a-431e-a7af-72b8232572b8.png)

![image (2)](https://user-images.githubusercontent.com/22449698/141298408-d4742882-47d3-42e1-89b4-5ba171aec373.png)

> Note: latter message grammar errors will be fixed on Mergin side