### PR TITLE
Add option to configure selective sync

### DIFF
--- a/Mergin/metadata.txt
+++ b/Mergin/metadata.txt
@@ -1,7 +1,7 @@
 ; the next section is mandatory
 [general]
 name=Mergin
-qgisMinimumVersion=3.10
+qgisMinimumVersion=3.16
 qgisMaximumVersion=3.99
 description=Handle Mergin projects
 version=2021.4.3

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -33,6 +33,7 @@ from urllib.error import URLError
 from .configuration_dialog import ConfigurationDialog
 from .create_project_wizard import NewMerginProjectWizard
 from .clone_project_dialog import CloneProjectDialog
+from .project_settings_widget import MerginProjectConfigFactory
 from .projects_manager import MerginProjectsManager
 from .sync_dialog import SyncDialog
 from .utils import (
@@ -137,6 +138,10 @@ class MerginPlugin:
         # related to https://github.com/lutraconsulting/qgis-mergin-plugin/issues/3
         # if self.iface.browserModel().initialized():
         #     self.iface.browserModel().reload()
+
+        # register custom mergin widget in project properties
+        self.mergin_project_config_factory = MerginProjectConfigFactory()
+        self.iface.registerProjectPropertiesWidgetFactory(self.mergin_project_config_factory)
 
     def add_action(
         self,
@@ -316,6 +321,8 @@ class MerginPlugin:
             self.iface.removePluginMenu(self.menu, action)
             self.iface.removeToolBarIcon(action)
         del self.toolbar
+
+        self.iface.unregisterProjectPropertiesWidgetFactory(self.mergin_project_config_factory)
 
 
 class MerginRemoteProjectItem(QgsDataItem):

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -1,0 +1,73 @@
+import json
+import os
+from qgis.PyQt import uic
+from qgis.gui import QgsOptionsWidgetFactory, QgsOptionsPageWidget
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QFileDialog
+from .utils import icon_path, mergin_project_local_path
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_project_config.ui')
+ProjectConfigUiWidget, _ = uic.loadUiType(ui_file)
+
+
+class MerginProjectConfigFactory(QgsOptionsWidgetFactory):
+    def __init__(self):
+        QgsOptionsWidgetFactory.__init__(self)
+
+    def icon(self):
+        return QIcon(icon_path("icon.png", fa_icon=False))
+
+    def title(self):
+        return "Mergin"
+
+    def createWidget(self, parent):
+        return ProjectConfigWidget(parent)
+
+
+class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
+    def __init__(self, parent=None):
+        QgsOptionsPageWidget.__init__(self, parent)
+        self.setupUi(self)
+        self.local_project_dir = mergin_project_local_path()
+
+        if self.local_project_dir:
+            self.config_file = os.path.join(self.local_project_dir, "mergin-config.json")
+            self.load_config_file()
+            self.btn_get_sync_dir.clicked.connect(self.get_sync_dir)
+        else:
+            self.selective_sync_group.setEnabled(False)
+
+    def get_sync_dir(self):
+        abs_path = QFileDialog.getExistingDirectory(None, "Select directory", self.local_project_dir, QFileDialog.ShowDirsOnly)
+        if self.local_project_dir not in abs_path:
+            return
+        dir_path = abs_path.replace(self.local_project_dir, "").lstrip("/")
+        self.edit_sync_dir.setText(dir_path)
+
+    def load_config_file(self):
+        if not self.local_project_dir or not os.path.exists(self.config_file):
+            return
+
+        with open(self.config_file, "r") as f:
+            config = json.load(f)
+            self.edit_sync_dir.setText(config["input-selective-sync-dir"])
+            self.chk_sync_enabled.setChecked(config["input-selective-sync"])
+
+    def save_config_file(self):
+        if not self.local_project_dir:
+            return
+
+        if os.path.exists(self.config_file):
+            with open(self.config_file, "r") as f:
+                config = json.load(f)
+        else:
+            config = {}
+
+        config["input-selective-sync"] = self.chk_sync_enabled.isChecked()
+        config["input-selective-sync-dir"] = self.edit_sync_dir.text()
+
+        with open(self.config_file, "w") as f:
+            json.dump(config, f, indent=2)
+
+    def apply(self):
+        self.save_config_file()

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QWidget</class>
+ <widget class="QWidget" name="QWidget">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>501</width>
+    <height>148</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Mergin Project</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="selective_sync_group">
+       <property name="title">
+        <string>Selective sync</string>
+       </property>
+       <widget class="QLabel" name="label">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>30</y>
+          <width>451</width>
+          <height>17</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>This is configuration for selective sync for Input in Mergin project.</string>
+        </property>
+       </widget>
+       <widget class="QCheckBox" name="chk_sync_enabled">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>60</y>
+          <width>401</width>
+          <height>23</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Enable selective sync for Input</string>
+        </property>
+       </widget>
+       <widget class="QWidget" name="layoutWidget">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>80</y>
+          <width>461</width>
+          <height>41</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="select_dir_layout">
+         <item>
+          <widget class="QLabel" name="label_sync_dir">
+           <property name="text">
+            <string> Only apply for folder: </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edit_sync_dir">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>175</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="placeholderText">
+            <string>Select sync directory</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btn_get_sync_dir">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR adds a new tab in projects properties related to mergin project. Currently it enables to configure selective sync for Input. If open project is not a mergin project, this option is disabled.

![2021-12-08_10-55](https://user-images.githubusercontent.com/23185498/145195900-f0abf0a7-e9c1-4a10-b769-fbaf87647945.png)

Needs update to QGIS 3.16

Closes #282 