### PR TITLE
Remove trailing backslash when comparing mergin servers names

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -181,7 +181,7 @@ class MerginProjectsManager(object):
                 continue
             proj_server = server
             break
-        if proj_server is not None and proj_server == self.mc.url.rstrip("/"):
+        if proj_server is not None and proj_server.rstrip("/") == self.mc.url.rstrip("/"):
             return True
         if inform_user:
             info = f"Current project was created for another Mergin server:\n{proj_server}\n\n"


### PR DESCRIPTION
PR fixes the issue with mergin server name saved in settings. In case that original server name contained trailing backslash and then server URL was updated without it, project would fail complaining about different servers.

Server names are now compared always without trailing backslash.

closes #285 