### PR TITLE
Avoid hitting assert in qgsprojectproperties

### DIFF
--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>QWidget</class>
- <widget class="QWidget" name="QWidget">
+ <widget class="QWidget" name="Mergin">
   <property name="enabled">
    <bool>true</bool>
   </property>


### PR DESCRIPTION
Opening the project properties in debug builds of qgis is hitting an assert leading to a crash:
```
Fatal: ASSERT failure in QgsProjectProperties::checkPageWidgetNameMap(): "QgisApp::projectPropertiesPagesMap() is outdated, please update. Mergin should be QWidget not Mergin", file /home/uclaros/dev/cpp/QGIS/src/app/qgsprojectproperties.cpp, line 2637
```

Fixes #336