### PR TITLE
Handle unfinished pull

### DIFF
--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -7,7 +7,10 @@ from PyQt5.QtWidgets import (
     QTabWidget,
     QTreeView,
     QVBoxLayout,
+    QHBoxLayout,
     QWidget,
+    QStyle,
+    QSizePolicy
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QStandardItemModel, QStandardItem, QIcon
@@ -53,6 +56,23 @@ class ProjectStatusDialog(QDialog):
         self.tabs.addTab(self.valid_tab, "Validation results")
 
         status_lay = QVBoxLayout(self.status_tab)
+        if self.mp.has_unfinished_pull():
+            warn_lay = QHBoxLayout()
+            lbl_warn_icon = QLabel()
+            lbl_warn_icon.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+            icon = self.style().standardIcon(QStyle.SP_MessageBoxWarning)
+            lbl_warn_icon.setPixmap(icon.pixmap(icon.availableSizes()[0]))
+            warn_lay.addWidget(lbl_warn_icon)
+            lbl_unfinished = QLabel()
+            lbl_unfinished.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+            lbl_unfinished.setWordWrap(True)
+            lbl_unfinished.setText(
+                "The previous pull has not finished completely: status "
+                "of some files may be reported incorrectly."
+            )
+            warn_lay.addWidget(lbl_unfinished)
+            status_lay.addLayout(warn_lay)
+
         status_lay.addWidget(self.table)
         has_files_to_replace = any(
             ["diff" not in file and is_versioned_file(file["path"]) for file in push_changes["updated"]]


### PR DESCRIPTION
Implement additional checks and logic for handling unfinished pull, as described in #327.

Following workflow was implemented:

1. When sync initiated plugin checks whether previous pull was completed successfully. If unfinished pull was found we try to finish it (if project is opened in QGIS it will be closed beforehand and then re-opened). As finishing previous pull means creation of conflicted copies, sync is stopped and user asked to check conflicts to prevent data loss. 
2. If project is in clean state first phase of sync (pull) started
3. Pull might fail and project will end up in the unfinished pull state. So we close project and try to finish pull. At this point sync will stop, because on success we will have conflict files and on failure we still have unfinished pull.
4. If pull completed without any errors we are going to push changes.

Also add a warning about unfinished pull to the status dialog if project has one
![unfinished-pull-warning](https://user-images.githubusercontent.com/776954/157745659-ceb88961-0885-4c4e-bb4e-bd41b85f214d.png)

And display message bar on project load if it has unfinished pull
![open_warning](https://user-images.githubusercontent.com/776954/157745794-ecd9367f-c5a7-4161-86ab-ec2776108286.png)

To provide user with the list of conflict files created while finalizing unfinished pull I have modified Python client code to provide this information lutraconsulting/mergin-py-client#129