### PR TITLE
handle exception which may be raised when creating report

### DIFF
--- a/Mergin/processing/algs/create_report.py
+++ b/Mergin/processing/algs/create_report.py
@@ -16,7 +16,8 @@ from ...utils import (
     icon_path,
     create_mergin_client,
     create_report,
-    ClientError
+    ClientError,
+    InvalidProject
 )
 
 
@@ -70,6 +71,8 @@ class CreateReport(QgsProcessingAlgorithm):
         warnings = None
         try:
             warnings = create_report(mc, project_dir, f"v{start}", f"v{end}", output_file)
+        except InvalidProject as e:
+            raise QgsProcessingException('Invalid Mergin project: ' + str(e))
         except ClientError as e:
             raise QgsProcessingException('Unable to create report: ' + str(e))
 

--- a/Mergin/processing/algs/create_report.py
+++ b/Mergin/processing/algs/create_report.py
@@ -15,7 +15,8 @@ from qgis.core import (
 from ...utils import (
     icon_path,
     create_mergin_client,
-    create_report
+    create_report,
+    ClientError
 )
 
 
@@ -66,7 +67,12 @@ class CreateReport(QgsProcessingAlgorithm):
         output_file = self.parameterAsFileOutput(parameters, self.REPORT, context)
 
         mc = create_mergin_client()
-        warnings = create_report(mc, project_dir, f"v{start}", f"v{end}", output_file)
+        warnings = None
+        try:
+            warnings = create_report(mc, project_dir, f"v{start}", f"v{end}", output_file)
+        except ClientError as e:
+            raise QgsProcessingException('Unable to create report: ' + str(e))
+
         if warnings:
             for w in warnings:
                 feedback.pushWarning(w)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -43,7 +43,7 @@ from .mergin.merginproject import MerginProject
 
 try:
     from .mergin import InvalidProject
-    from .mergin.client import MerginClient, ClientError, LoginError
+    from .mergin.client import MerginClient, ClientError, LoginError, InvalidProject
     from .mergin.client_pull import download_project_async, download_project_is_running, \
                                     download_project_finalize, download_project_cancel
     from .mergin.client_pull import pull_project_async, pull_project_is_running, \


### PR DESCRIPTION
Reporting code in the Mergin Python client can raise ClientError. Handle it in the Processing tool and gracefully fail instead of showing traceback.