### PR TITLE
Fix "Remove locally" functionality (fix #352)

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -535,6 +535,9 @@ class MerginLocalProjectItem(QgsDirectoryItem):
                 mp.log.removeHandler(log_file_handler)
                 del mp
 
+                # as releasing lock on previously open files takes some time
+                # we have to wait a bit before removing them, otherwise rmtree
+                # will fail and removal of the local rpoject will fail as well
                 QTimer.singleShot(250, lambda: shutil.rmtree(self.path))
             except PermissionError as e:
                 QgsApplication.messageLog().logMessage(f"Mergin plugin: {str(e)}")

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from pathlib import Path
 import posixpath
-from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtCore import pyqtSignal, QTimer
 from qgis.PyQt.QtGui import QIcon
 from qgis.core import (
     QgsApplication,
@@ -535,7 +535,7 @@ class MerginLocalProjectItem(QgsDirectoryItem):
                 mp.log.removeHandler(log_file_handler)
                 del mp
 
-                shutil.rmtree(self.path)
+                QTimer.singleShot(250, lambda: shutil.rmtree(self.path))
             except PermissionError as e:
                 QgsApplication.messageLog().logMessage(f"Mergin plugin: {str(e)}")
                 msg = (


### PR DESCRIPTION
On Windows when QGIS project is cleared OS needs some time to release lock on open files. So when we try to remove files they still might be locked. As a result removing local project copy will file. To avoid this we add a small delay before attempt to remove Mergin project files.

Fixes #352.