### PR TITLE
take into account namespace permissions to get user privileges (fix #351)

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -49,7 +49,12 @@ class MerginProjectsManager(object):
         info = self.mc.project_info(project_name)
         username = self.mc.username()
         writersnames = info["access"]["writersnames"]
-        return username in writersnames
+        permissions = info["permissions"]
+        # permissions field contains information about update, delete and upload
+        # privileges of the user on a specific project. This is more accurate
+        # information then "writernames" field, as it takes into account
+        # namespace privileges. So we have to check both "writersnames" and "permissions"
+        return (username in writersnames) or all(permissions.values())
 
     def open_project(self, project_dir):
         if not project_dir:

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -53,8 +53,8 @@ class MerginProjectsManager(object):
         # permissions field contains information about update, delete and upload
         # privileges of the user on a specific project. This is more accurate
         # information then "writernames" field, as it takes into account
-        # namespace privileges. So we have to check both "writersnames" and "permissions"
-        return (username in writersnames) or all(permissions.values())
+        # namespace privileges. So we have to check "upload" field from "permissions"
+        return permissions["upload"]
 
     def open_project(self, project_dir):
         if not project_dir:

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -168,7 +168,7 @@ class MerginProjectsManager(object):
                 pull_changes,
                 push_changes,
                 push_changes_summary,
-                self.mc.have_writing_permissions(project_dir),
+                self.mc.has_writing_permissions(project_name),
                 validation_results,
                 mp
             )
@@ -268,7 +268,7 @@ class MerginProjectsManager(object):
             return
 
         # pull finished, start push
-        if any(push_changes.values()) and not self.mc.have_writing_permissions(project_dir):
+        if any(push_changes.values()) and not self.mc.has_writing_permissions(project_name):
             QMessageBox.information(
                 None, "Project sync", "You have no writing rights to this project", QMessageBox.Close
             )

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -44,18 +44,6 @@ class MerginProjectsManager(object):
             return True if unsaved_project_check() else False
         return True  # not a Mergin project
 
-    def have_writing_permissions(self, project_name):
-        """Check if user have writing rights to the project."""
-        info = self.mc.project_info(project_name)
-        username = self.mc.username()
-        writersnames = info["access"]["writersnames"]
-        permissions = info["permissions"]
-        # permissions field contains information about update, delete and upload
-        # privileges of the user on a specific project. This is more accurate
-        # information then "writernames" field, as it takes into account
-        # namespace privileges. So we have to check "upload" field from "permissions"
-        return permissions["upload"]
-
     def open_project(self, project_dir):
         if not project_dir:
             return
@@ -180,7 +168,7 @@ class MerginProjectsManager(object):
                 pull_changes,
                 push_changes,
                 push_changes_summary,
-                self.have_writing_permissions(project_name),
+                self.mc.have_writing_permissions(project_dir),
                 validation_results,
                 mp
             )
@@ -280,7 +268,7 @@ class MerginProjectsManager(object):
             return
 
         # pull finished, start push
-        if any(push_changes.values()) and not self.have_writing_permissions(project_name):
+        if any(push_changes.values()) and not self.mc.have_writing_permissions(project_dir):
             QMessageBox.information(
                 None, "Project sync", "You have no writing rights to this project", QMessageBox.Close
             )


### PR DESCRIPTION
As described in #351 when user who is not an owner of the organization tries to sync project of the organization they get error. It happens because plugin relies on the `access` field of the project information to determine whether user has write permissions on a given project. However `access` field is taken from the explicit project permissions, while invited to the organization users get access via this organization.

In order to overcome this issue we need to check write access also by using `permissions` field, as this field is evaluated with respect to namespace.

Also need to fix the same issues in the Python client lutraconsulting/mergin-py-client#130

Fixes #351