### PR TITLE
disable sync and status buttons when project was removed locally (fix #359)

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -525,6 +525,9 @@ class MerginLocalProjectItem(QgsDirectoryItem):
                         return
 
                     cur_proj.clear()
+                    # clearing project does not trigger toggling toolbar buttons state
+                    # change, so we need to fire the singnal manually
+                    iface.newProjectCreated.emit()
                     registry = QgsProviderRegistry.instance()
                     registry.setLibraryDirectory(registry.libraryDirectory())
 


### PR DESCRIPTION
Clearing project does not fires signals which trigger buttons state update. So we have to fire signal manually.

Fixes #359.