### PR TITLE
Improve validation/sync workflow and status dialog overhaul

### DIFF
--- a/Mergin/help.py
+++ b/Mergin/help.py
@@ -1,0 +1,14 @@
+
+HELP_ROOT = "https://merginmaps.com/docs"
+
+
+class MerginHelp:
+    """Class for generating Mergin plugin help URLs."""
+
+    def howto_attachment_widget(self):
+        return f"{HELP_ROOT}/layer/settingup_forms/"
+
+    def howto_background_maps(self):
+        return f"{HELP_ROOT}/gis/settingup_background_map/"
+
+

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -297,7 +297,7 @@ class MerginPlugin:
 
     def current_project_sync(self):
         """Synchronise current Mergin project."""
-        self.manager.project_status(self.mergin_proj_dir, show_sync_button=True)
+        self.manager.project_status(self.mergin_proj_dir)
 
     def on_qgis_project_changed(self):
         """
@@ -488,7 +488,7 @@ class MerginLocalProjectItem(QgsDirectoryItem):
     def sync_project(self):
         if not self.path:
             return
-        self.project_manager.project_status(self.path, show_sync_button=True)
+        self.project_manager.project_status(self.path)
 
     def _reload_project(self):
         """ This will forcefully reload the QGIS project because the project (or its data) may have changed """

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -297,7 +297,7 @@ class MerginPlugin:
 
     def current_project_sync(self):
         """Synchronise current Mergin project."""
-        self.manager.sync_project(self.mergin_proj_dir)
+        self.manager.project_status(self.mergin_proj_dir, show_sync_button=True)
 
     def on_qgis_project_changed(self):
         """
@@ -488,7 +488,7 @@ class MerginLocalProjectItem(QgsDirectoryItem):
     def sync_project(self):
         if not self.path:
             return
-        self.project_manager.sync_project(self.path, self.project_name)
+        self.project_manager.project_status(self.path, show_sync_button=True)
 
     def _reload_project(self):
         """ This will forcefully reload the QGIS project because the project (or its data) may have changed """

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -32,18 +32,17 @@ class ProjectStatusDialog(QDialog):
 
     def __init__(
         self, pull_changes, push_changes, push_changes_summary, has_write_permissions, validation_results,
-            mergin_project=None, parent=None, show_sync_button=False
+            mergin_project=None, parent=None
     ):
         QDialog.__init__(self, parent)
         self.ui = uic.loadUi(ui_file, self)
 
         QgsGui.instance().enableAutoGeometryRestore(self)
 
-        if show_sync_button:
-            self.btn_sync = QPushButton("Sync")
-            # add sync button with AcceptRole. If dialog accepted we will start
-            # sync, otherwise just close status dialog
-            self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
+        self.btn_sync = QPushButton("Sync")
+        # add sync button with AcceptRole. If dialog accepted we will start
+        # sync, otherwise just close status dialog
+        self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
 
         self.validation_results = validation_results
         self.mp = mergin_project

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -7,13 +7,14 @@ from qgis.PyQt.QtWidgets import (
     QDialogButtonBox,
     QStyle,
     QSizePolicy,
-    QPushButton
+    QPushButton,
+    QLabel
 )
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from qgis.gui import QgsGui
-from qgis.core import QgsApplication, QgsProject
+from qgis.core import Qgis, QgsApplication, QgsProject
 from .utils import is_versioned_file
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_status_dialog.ui')
@@ -67,7 +68,10 @@ class ProjectStatusDialog(QDialog):
         )
         info_text = self._get_info_text(has_files_to_replace, has_write_permissions, self.mp.has_unfinished_pull())
         for msg in info_text:
-            self.ui.messageBar.pushWarning("WARNING", msg)
+            lbl = QLabel(msg)
+            lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+            lbl.setWordWrap(True)
+            self.ui.messageBar.pushWidget(lbl, Qgis.Warning)
 
     def _get_info_text(self, has_files_to_replace, has_write_permissions, has_unfinished_pull):
         msg = []

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -7,15 +7,16 @@ from qgis.PyQt.QtWidgets import (
     QDialogButtonBox,
     QSizePolicy,
     QPushButton,
-    QLabel
+    QLabel,
 )
+from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from qgis.gui import QgsGui
 from qgis.core import Qgis, QgsApplication, QgsProject
 
 from .validation import MultipleLayersWarning, warning_display_string
-from .utils import is_versioned_file
+from .utils import is_versioned_file, icon_path
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_status_dialog.ui')
 
@@ -39,7 +40,9 @@ class ProjectStatusDialog(QDialog):
 
         QgsGui.instance().enableAutoGeometryRestore(self)
 
-        self.btn_sync = QPushButton("Sync")
+        self.btn_sync = QPushButton(" Sync")
+        self.btn_sync.setIcon(QIcon(icon_path("sync-solid.svg")))
+        self.btn_sync.setIconSize(QSize(12, 12))
         # add sync button with AcceptRole. If dialog accepted we will start
         # sync, otherwise just close status dialog
         self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
@@ -59,8 +62,10 @@ class ProjectStatusDialog(QDialog):
         if not self.validation_results:
             self.ui.lblWarnings.hide()
             self.ui.txtWarnings.hide()
+            self.btn_sync.setStyleSheet("background-color: #90ee90")
         else:
             self.show_validation_results()
+            self.btn_sync.setStyleSheet("background-color: #ffc800")
 
         has_files_to_replace = any(
             ["diff" not in file and is_versioned_file(file["path"]) for file in push_changes["updated"]]

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -40,8 +40,9 @@ class ProjectStatusDialog(QDialog):
 
         if show_sync_button:
             self.btn_sync = QPushButton("Sync")
-            self.btn_sync.clicked.connect(self.sync_project)
-            self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.ActionRole)
+            # add sync button with AcceptRole. If dialog accepted we will start
+            # sync, otherwise just close status dialog
+            self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
 
         self.validation_results = validation_results
         self.mp = mergin_project
@@ -155,6 +156,3 @@ class ProjectStatusDialog(QDialog):
             html.append(f"<ul>{''.join(items)}</ul>")
 
         self.txtWarnings.setHtml(''.join(html))
-
-    def sync_project(self):
-        pass

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -2,15 +2,12 @@ import os
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import (
-    QAbstractItemView,
     QDialog,
     QDialogButtonBox,
-    QStyle,
     QSizePolicy,
     QPushButton,
     QLabel
 )
-from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from qgis.gui import QgsGui

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -1,21 +1,22 @@
 import os
-from PyQt5.QtWidgets import (
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import (
     QAbstractItemView,
     QDialog,
     QDialogButtonBox,
-    QLabel,
-    QTabWidget,
-    QTreeView,
-    QVBoxLayout,
-    QHBoxLayout,
-    QWidget,
     QStyle,
-    QSizePolicy
+    QSizePolicy,
+    QPushButton
 )
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QStandardItemModel, QStandardItem, QIcon
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
+
+from qgis.gui import QgsGui
 from qgis.core import QgsApplication, QgsProject
 from .utils import is_versioned_file
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_status_dialog.ui')
 
 
 class ProjectStatusDialog(QDialog):
@@ -30,82 +31,60 @@ class ProjectStatusDialog(QDialog):
 
     def __init__(
         self, pull_changes, push_changes, push_changes_summary, has_write_permissions, validation_results,
-            mergin_project=None, parent=None
+            mergin_project=None, parent=None, show_sync_button=False
     ):
-        super(ProjectStatusDialog, self).__init__(parent)
+        QDialog.__init__(self, parent)
+        self.ui = uic.loadUi(ui_file, self)
+
+        QgsGui.instance().enableAutoGeometryRestore(self)
+
+        if show_sync_button:
+            self.btn_sync = QPushButton("Sync")
+            self.btn_sync.clicked.connect(self.sync_project)
+            self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.ActionRole)
+
         self.validation_results = validation_results
-        self.setWindowTitle("Project status")
-        self.table = QTreeView()
-        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.mp = mergin_project
+
         self.model = QStandardItemModel()
         self.model.setHorizontalHeaderLabels(["Status"])
-        self.table.setModel(self.model)
-        self.mp = mergin_project
+        self.treeStatus.setModel(self.model)
 
         self.check_any_changes(pull_changes, push_changes)
         self.add_content(pull_changes, "Server changes", True)
         self.add_content(push_changes, "Local changes", False, push_changes_summary)
-        self.table.expandAll()
+        self.treeStatus.expandAll()
 
-        main_lout = QVBoxLayout(self)
-        self.tabs = QTabWidget()
-        main_lout.addWidget(self.tabs)
-        self.status_tab = QWidget()
-        self.valid_tab = QWidget()
-        self.tabs.addTab(self.status_tab, "Status")
-        self.tabs.addTab(self.valid_tab, "Validation results")
+        if not self.validation_results:
+            self.ui.lblWarnings.hide()
+            self.ui.txtWarnings.hide()
+        else:
+            self.show_validation_results()
 
-        status_lay = QVBoxLayout(self.status_tab)
-        if self.mp.has_unfinished_pull():
-            warn_lay = QHBoxLayout()
-            lbl_warn_icon = QLabel()
-            lbl_warn_icon.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
-            icon = self.style().standardIcon(QStyle.SP_MessageBoxWarning)
-            lbl_warn_icon.setPixmap(icon.pixmap(icon.availableSizes()[0]))
-            warn_lay.addWidget(lbl_warn_icon)
-            lbl_unfinished = QLabel()
-            lbl_unfinished.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-            lbl_unfinished.setWordWrap(True)
-            lbl_unfinished.setText(
-                "The previous pull has not finished completely: status "
-                "of some files may be reported incorrectly."
-            )
-            warn_lay.addWidget(lbl_unfinished)
-            status_lay.addLayout(warn_lay)
-
-        status_lay.addWidget(self.table)
         has_files_to_replace = any(
             ["diff" not in file and is_versioned_file(file["path"]) for file in push_changes["updated"]]
         )
-        info_text = self._get_info_text(has_files_to_replace, has_write_permissions)
-        if info_text:
-            text_box = QLabel()
-            text_box.setWordWrap(True)
-            text_box.setText(info_text)
-            status_lay.addWidget(text_box)
+        info_text = self._get_info_text(has_files_to_replace, has_write_permissions, self.mp.has_unfinished_pull())
+        for msg in info_text:
+            self.ui.messageBar.pushWarning("WARNING", msg)
 
-        box = QDialogButtonBox(QDialogButtonBox.Ok, centerButtons=True,)
-        box.accepted.connect(self.accept)
-        box.rejected.connect(self.reject)
-        main_lout.addWidget(box, Qt.AlignCenter)
-
-        self.valid_view = QTreeView()
-        self.valid_view.setStyleSheet("QTreeView::item { padding: 5px }")
-        self.valid_model = QStandardItemModel()
-        self.show_validation_results()
-
-        self.resize(640, 640)
-
-    def _get_info_text(self, has_files_to_replace, has_write_permissions):
-        msg = ""
+    def _get_info_text(self, has_files_to_replace, has_write_permissions, has_unfinished_pull):
+        msg = []
         if not has_write_permissions:
-            msg += f"WARNING: You don't have writing permissions to this project. Changes won't be synced!\n"
+            msg.append(f"You don't have writing permissions to this project. Changes won't be synced!")
 
         if has_files_to_replace:
-            msg += (
-                f"\nWARNING: Unable to compare some of the modified files with their server version - "
+            msg.append(
+                f"Unable to compare some of the modified files with their server version - "
                 f"their history will be lost if uploaded."
             )
+
+        if has_unfinished_pull:
+            msg.append(
+                f"The previous pull has not finished completely: status "
+                f"of some files may be reported incorrectly."
+            )
+
         return msg
 
     def check_any_changes(self, pull_changes, push_changes):
@@ -163,22 +142,19 @@ class ProjectStatusDialog(QDialog):
         return item
 
     def show_validation_results(self):
-        lout = QVBoxLayout(self.valid_tab)
-        lout.addWidget(self.valid_view)
-        self.valid_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        self.valid_model.setHorizontalHeaderLabels(["Validation results"])
-        self.valid_view.setModel(self.valid_model)
-
+        html = []
         map_layers = QgsProject.instance().mapLayers()
         for issues_data in sorted(self.validation_results):
             level, issue = issues_data
             layer_ids = self.validation_results[issues_data]
-            issue_item = QStandardItem(issue)
+            html.append(f"<h3>{issue}</h3>")
+            items = []
             for lid in sorted(layer_ids, key=lambda x: map_layers[x].name()):
                 layer = map_layers[lid]
-                lyr_item = QStandardItem(f"- {layer.name()}")
-                lyr_item.setToolTip(layer.publicSource())
-                issue_item.appendRow(lyr_item)
-            self.valid_model.appendRow(issue_item)
+                items.append(f"<li>{layer.name()}</li>")
+            html.append(f"<ul>{''.join(items)}</ul>")
 
-        self.valid_view.expandAll()
+        self.txtWarnings.setHtml(''.join(html))
+
+    def sync_project(self):
+        pass

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -145,7 +145,7 @@ class MerginProjectsManager(object):
 
         return True
 
-    def project_status(self, project_dir):
+    def project_status(self, project_dir, show_sync_button=False):
         if project_dir is None:
             return
         if not unsaved_project_check():
@@ -170,9 +170,14 @@ class MerginProjectsManager(object):
                 push_changes_summary,
                 self.mc.has_writing_permissions(project_name),
                 validation_results,
-                mp
+                mp,
+                show_sync_button=show_sync_button
             )
-            dlg.exec_()
+            # Sync button in the status dialog returns QDialog.Accepted
+            # and Close button retuns QDialog::Rejected, so it dialog was
+            # accepted we start sync
+            if dlg.exec_():
+                self.sync_project(project_dir)
 
         except (URLError, ClientError, InvalidProject) as e:
             msg = f"Failed to get status for project {project_name}:\n\n{str(e)}"

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -145,7 +145,7 @@ class MerginProjectsManager(object):
 
         return True
 
-    def project_status(self, project_dir, show_sync_button=False):
+    def project_status(self, project_dir):
         if project_dir is None:
             return
         if not unsaved_project_check():
@@ -170,8 +170,7 @@ class MerginProjectsManager(object):
                 push_changes_summary,
                 self.mc.has_writing_permissions(project_name),
                 validation_results,
-                mp,
-                show_sync_button=show_sync_button
+                mp
             )
             # Sync button in the status dialog returns QDialog.Accepted
             # and Close button retuns QDialog::Rejected, so it dialog was

--- a/Mergin/test/test_help.py
+++ b/Mergin/test/test_help.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import os
+import urllib.request
+
+from qgis.testing import start_app, unittest
+from Mergin.help import MerginHelp
+
+test_data_path = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class test_help(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        start_app()
+
+    def test_help_urls(self):
+        mh = MerginHelp()
+
+        req = urllib.request.Request(mh.howto_attachment_widget(), method="HEAD")
+        resp = urllib.request.urlopen(req)
+        self.assertEqual(resp.status, 200)
+
+        req = urllib.request.Request(mh.howto_background_maps(), method="HEAD")
+        resp = urllib.request.urlopen(req)
+        self.assertEqual(resp.status, 200)
+
+if __name__ == '__main__':
+    nose2.main()

--- a/Mergin/ui/ui_status_dialog.ui
+++ b/Mergin/ui/ui_status_dialog.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>416</width>
+    <height>345</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Project status</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QgsMessageBar" name="messageBar">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeView" name="treeStatus">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblWarnings">
+     <property name="text">
+      <string>Warnings</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="txtWarnings">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QFrame</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Mergin/ui/ui_status_dialog.ui
+++ b/Mergin/ui/ui_status_dialog.ui
@@ -42,8 +42,14 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="txtWarnings">
+    <widget class="QTextBrowser" name="txtWarnings">
      <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
+     </property>
+     <property name="openExternalLinks">
       <bool>true</bool>
      </property>
     </widget>

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -1,5 +1,6 @@
-from collections import defaultdict
 import os
+from enum import Enum
+from collections import defaultdict
 
 from qgis.core import (
     QgsMapLayerType,
@@ -17,30 +18,51 @@ from .utils import (
 )
 
 
+class Warning(Enum):
+    PROJ_NOT_LOADED = 1
+    PROJ_NOT_FOUND = 2
+    MULTIPLE_PROJS = 3
+    ABSOLUTE_PATHS = 4
+    EDITABLE_NON_GPKG = 5
+    EXTERNAL_SRC = 6
+    NOT_FOR_OFFLINE = 7
+    NO_EDITABLE_LAYERS = 8
+    ATTACHMENT_ABSOLUTE_PATH = 9
+    ATTACHMENT_LOCAL_PATH = 10
+    ATTACHMENT_EXPRESSION_PATH = 11
+    ATTACHMENT_HYPERLINK = 12
+    DATABASE_SCHEMA_CHANGE = 13
+
+
+class MultipleLayersWarning:
+    """Class for warning which is associated with multiple layers.
+
+    Some warnings, e.g. "layer not suitable for offline use" should be
+    displayed only once in the validation results and list all matching
+    layers.
+    """
+    def __init__(self, warning_id):
+        self.id = warning_id
+        self.layers = list()
+
+
+class SingleLayerWarning:
+    """Class for warning which is associated with single layer.
+    """
+    def __init__(self, layer_id, warning):
+        self.layer_id = layer_id
+        self.warning = warning
+
+
 class MerginProjectValidator(object):
     """Class for checking Mergin project validity and fixing the problems, if possible."""
-
-    NO_PROBLEMS = 0, "No problems found!"  # level, description
-    MULTIPLE_PROJS = 0, "Multiple QGIS project files found in the directory"
-    PROJ_NOT_LOADED = 0, "The QGIS project is not loaded. Open it to allow validation"
-    PROJ_NOT_FOUND = 0, "No QGIS project found in the directory"
-    ABSOLUTE_PATHS = 1, "QGIS project saves layers using absolute paths"
-    EDITABLE_NON_GPKG = 2, "Editable layer stored in a format other than GeoPackage"
-    EXTERNAL_SRC = 3, "Layer stored out of the project directory"
-    NOT_FOR_OFFLINE = 5, "Layer might not be available when offline"
-    NO_EDITABLE_LAYER = 7, "No editable layer in the project"
-    ATTACHMENT_ABSOLUTE_PATH = 8, "Attachment widget uses absolute paths"
-    ATTACHMENT_LOCAL_PATH = 9, "Attachment widget uses local path"
-    ATTACHMENT_EXPRESSION_PATH = 10, "Attachment widget incorrectly uses expression-based path"
-    ATTACHMENT_HYPERLINK = 11, "Attachment widget uses hyperlink"
-    DATABASE_SCHEMA_CHANGE = 12, "Database schema was changed"
 
     def __init__(self, mergin_project=None):
         self.mp = mergin_project
         self.layers = None  # {layer_id: map layer}
         self.editable = None  # list of editable layers ids
         self.layers_by_prov = defaultdict(list)  # {provider_name: [layers]}
-        self.issues = defaultdict(list)  # {problem type: optional list of problematic data sources, or None}
+        self.issues = list()
         self.qgis_files = None
         self.qgis_proj = None
         self.qgis_proj_path = None
@@ -63,19 +85,18 @@ class MerginProjectValidator(object):
         self.check_offline()
         self.check_attachment_widget()
         self.check_db_schema()
-        if not self.issues:
-            self.issues[self.NO_PROBLEMS] = []
+
         return self.issues
 
     def check_single_proj(self, project_dir):
         """Check if there is one and only one QGIS project in the directory."""
         self.qgis_files = find_qgis_files(project_dir)
         if len(self.qgis_files) > 1:
-            self.issues[self.MULTIPLE_PROJS] = []
+            self.issues.append(MultipleLayersWarning(Warning.MULTIPLE_PROJS))
             return False
         elif len(self.qgis_files) == 0:
             # might be deleted after opening in QGIS
-            self.issues[self.PROJ_NOT_FOUND] = []
+            self.issues.append(MultipleLayersWarning(Warning.PROJ_NOT_FOUND))
             return False
         return True
 
@@ -85,7 +106,7 @@ class MerginProjectValidator(object):
         loaded_proj_path = QgsProject.instance().absoluteFilePath()
         is_loaded = same_dir(self.qgis_proj_path, loaded_proj_path)
         if not is_loaded:
-            self.issues[self.PROJ_NOT_LOADED] = []
+            self.issues.append(MultipleLayersWarning(Warning.PROJ_NOT_LOADED))
         else:
             self.qgis_proj = QgsProject.instance()
         return is_loaded
@@ -95,7 +116,7 @@ class MerginProjectValidator(object):
         abs_paths, ok = self.qgis_proj.readEntry("Paths", "/Absolute")
         assert ok
         if not abs_paths == "false":
-            self.issues[self.ABSOLUTE_PATHS] = []
+            self.issues.append(MultipleLayersWarning(Warning.ABSOLUTE_PATHS))
 
     def get_proj_layers(self):
         """Get project layers and find those editable."""
@@ -116,7 +137,7 @@ class MerginProjectValidator(object):
                 if can_edit:
                     self.editable.append(layer.id())
         if len(self.editable) == 0:
-            self.issues[self.NO_EDITABLE_LAYER] = []
+            self.issues.append(MultipleLayersWarning(Warning.NO_EDITABLE_LAYERS))
 
     def check_editable_vectors_format(self):
         """Check if editable vector layers are GPKGs."""
@@ -125,7 +146,7 @@ class MerginProjectValidator(object):
                 continue
             dp = layer.dataProvider()
             if not dp.storageType() == "GPKG":
-                self.issues[self.EDITABLE_NON_GPKG].append(lid)
+                self.issues.append(SingleLayerWarning(lid, Warning.EDITABLE_NON_GPKG))
 
     def check_saved_in_proj_dir(self):
         """Check if layers saved in project"s directory."""
@@ -140,10 +161,11 @@ class MerginProjectValidator(object):
                 l_path = layer.publicSource().split("|")[0]
             l_dir = os.path.dirname(l_path)
             if not same_dir(l_dir, self.qgis_proj_dir):
-                self.issues[self.EXTERNAL_SRC].append(lid)
+                self.issues.append(SingleLayerWarning(lid, Warning.EXTERNAL_SRC))
 
     def check_offline(self):
         """Check if there are layers that might not be available when offline"""
+        w = MultipleLayersWarning(Warning.NOT_FOR_OFFLINE)
         for lid, layer in self.layers.items():
             try:
                 dp_name = layer.dataProvider().name()
@@ -151,7 +173,10 @@ class MerginProjectValidator(object):
                 # might be vector tiles - no provider name
                 continue
             if dp_name in QGIS_NET_PROVIDERS + QGIS_DB_PROVIDERS:
-                self.issues[self.NOT_FOR_OFFLINE].append(lid)
+                w.layers.append(lid)
+
+        if w.layers:
+            self.issues.append(w)
 
     def check_attachment_widget(self):
         """Check if attachment widget uses relative path."""
@@ -165,20 +190,20 @@ class MerginProjectValidator(object):
                     cfg = ws.config()
                     # check for relative paths
                     if cfg["RelativeStorage"] == 0:
-                        self.issues[self.ATTACHMENT_ABSOLUTE_PATH].append(lid)
+                        self.issues.append(SingleLayerWarning(lid, Warning.ATTACHMENT_ABSOLUTE_PATH))
                     if "DefaultRoot" in cfg:
                         # default root should not be set to the local path
                         if os.path.isabs(cfg["DefaultRoot"]):
-                            self.issues[self.ATTACHMENT_LOCAL_PATH].append(lid)
+                            self.issues.append(SingleLayerWarning(lid, Warning.ATTACHMENT_LOCAL_PATH))
 
                         # expression-based path should be set with the data-defined overrride
                         expr = QgsExpression(cfg["DefaultRoot"])
                         if expr.isValid():
-                            self.issues[self.ATTACHMENT_EXPRESSION_PATH].append(lid)
+                            self.issues.append(SingleLayerWarning(lid, Warning.ATTACHMENT_EXPRESSION_PATH))
 
                         # using hyperlinks for document path is not allowed when
                         if "UseLink" in cfg:
-                            self.issues[self.ATTACHMENT_HYPERLINK].append(lid)
+                            self.issues.append(SingleLayerWarning(lid, Warning.ATTACHMENT_HYPERLINK))
 
 
     def check_db_schema(self):
@@ -189,4 +214,35 @@ class MerginProjectValidator(object):
             if dp.storageType() == "GPKG":
                 has_change, msg = has_schema_change(self.mp, layer)
                 if not has_change:
-                    self.issues[self.DATABASE_SCHEMA_CHANGE].append(lid)
+                    self.issues.append(SingleLayerWarning(lid, Warning.DATABASE_SCHEMA_CHANGE))
+
+
+def warning_display_string(warning_id):
+    """Returns a display string for a corresponing warning
+    """
+    if warning_id == Warning.PROJ_NOT_LOADED:
+        return "The QGIS project is not loaded. Open it to allow validation"
+    elif warning_id == Warning.PROJ_NOT_FOUND:
+        return "No QGIS project found in the directory"
+    elif warning_id == Warning.MULTIPLE_PROJS:
+        return "Multiple QGIS project files found in the directory"
+    elif warning_id == Warning.ABSOLUTE_PATHS:
+        return "QGIS project saves layers using absolute paths"
+    elif warning_id == Warning.EDITABLE_NON_GPKG:
+        return "Editable layer stored in a format other than GeoPackage"
+    elif warning_id == Warning.EXTERNAL_SRC:
+        return "Layer stored out of the project directory"
+    elif warning_id == Warning.NOT_FOR_OFFLINE:
+        return "Layer might not be available when offline"
+    elif warning_id == Warning.NO_EDITABLE_LAYERS:
+        return "No editable layers in the project"
+    elif warning_id == Warning.ATTACHMENT_ABSOLUTE_PATH:
+        return "Attachment widget uses absolute paths"
+    elif warning_id == Warning.ATTACHMENT_LOCAL_PATH:
+        return "Attachment widget uses local path"
+    elif warning_id == Warning.ATTACHMENT_EXPRESSION_PATH:
+        return "Attachment widget incorrectly uses expression-based path"
+    elif warning_id == Warning.ATTACHMENT_HYPERLINK:
+        return "Attachment widget uses hyperlink"
+    elif warning_id == Warning.DATABASE_SCHEMA_CHANGE:
+        return "Database schema was changed"

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -9,6 +9,7 @@ from qgis.core import (
     QgsExpression
 )
 
+from .help import MerginHelp
 from .utils import (
     find_qgis_files,
     same_dir,
@@ -220,6 +221,7 @@ class MerginProjectValidator(object):
 def warning_display_string(warning_id):
     """Returns a display string for a corresponing warning
     """
+    help_mgr = MerginHelp()
     if warning_id == Warning.PROJ_NOT_LOADED:
         return "The QGIS project is not loaded. Open it to allow validation"
     elif warning_id == Warning.PROJ_NOT_FOUND:
@@ -233,11 +235,11 @@ def warning_display_string(warning_id):
     elif warning_id == Warning.EXTERNAL_SRC:
         return "Layer stored out of the project directory"
     elif warning_id == Warning.NOT_FOR_OFFLINE:
-        return "Layer might not be available when offline"
+        return f"Layer might not be available when offline. <a href='{help_mgr.howto_background_maps()}'>Read more.</a>"
     elif warning_id == Warning.NO_EDITABLE_LAYERS:
         return "No editable layers in the project"
     elif warning_id == Warning.ATTACHMENT_ABSOLUTE_PATH:
-        return "Attachment widget uses absolute paths"
+        return f"Attachment widget uses absolute paths. <a href='{help_mgr.howto_attachment_widget()}'>Read more.</a>"
     elif warning_id == Warning.ATTACHMENT_LOCAL_PATH:
         return "Attachment widget uses local path"
     elif warning_id == Warning.ATTACHMENT_EXPRESSION_PATH:


### PR DESCRIPTION
Show project status dialog before sync, so users can revise changes and be aware of any possible misconfigurations/changes which may break their project. Both "Sync" and "Status" toolbar buttons and context menu item will open the Project Status dialog. When invoked via "Sync" button the Project Status dialog will have a "Sync" button to start synchronization, otherwise only "Close" button will be shown.

Improve status dialog UI by:

- saving/restoring its size and position
- dropping tabs and making validation results more visible to user. If there are no warnings, validation results widget will be hidden to save space and avoid confusion.
- using message bar at the top of the dialog instead of the plain label at the bottom to display messages
- use rich text widget for validation results. This allows us to use long descriptions for warnings and include links to the documentation. Better text and links to be added.

In addition approach to handling validation results was changed a bit. For some checks (like the one checking for online/offline layers) we show all affected layers under the warning name. While results of other checks are grouped by a layer. This should make it easier for users to review warnings and fix them.

Before (left - Project Status tab, right - Validation results tab)
![зображення](https://user-images.githubusercontent.com/776954/161098432-e9cd7c18-12cd-496f-b725-6979e3cdcaca.png)

After (left - Status dialog, both status and validation results are visible, right - Status dialog, validation widget is hidden as there are no warnings)
![зображення](https://user-images.githubusercontent.com/776954/161099683-0f74a6b9-6af8-4a26-805b-0726584d820a.png)
