### PR TITLE
drop caret returns from JSON before reading it (fix #378)

### DIFF
--- a/Mergin/test/test_validations.py
+++ b/Mergin/test/test_validations.py
@@ -56,6 +56,5 @@ class test_validations(unittest.TestCase):
         self.assertFalse(equal)
         self.assertEqual(msg, "Definition of 'date' field in 'Survey_points' table is not the same")
 
-
 if __name__ == '__main__':
     nose2.main()

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -901,6 +901,22 @@ def is_number(s):
         return False
 
 
+def get_schema(layer_path):
+    """
+    Return JSON representation of the layer schema
+    """
+    geodiff = pygeodiff.GeoDiff()
+
+    tmp_file = tempfile.NamedTemporaryFile(delete=False)
+    tmp_file.close()
+    geodiff.schema('sqlite', '', layer_path, tmp_file.name)
+    with open(tmp_file.name, encoding="utf-8") as f:
+        data = f.read()
+        schema = json.loads(data.replace("\n", "")).get('geodiff_schema')
+    os.unlink(tmp_file.name)
+    return schema
+
+
 def has_schema_change(mp, layer):
     """
     Check whether the layer has schema changes using schema representaion
@@ -913,22 +929,9 @@ def has_schema_change(mp, layer):
     f_name = os.path.split(local_path)[1]
     base_path = mp.fpath_meta(f_name)
 
-    if not os.path.exists(base_path):
-        return True, "No schema changes"
+    base_schema = get_schema(base_path)
+    local_schema = get_schema(local_path)
 
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.close()
-    geodiff.schema('sqlite', '', local_path, tmp_file.name)
-    with open(tmp_file.name, encoding="utf-8") as f:
-        data = f.read()
-        base_schema = json.loads(data.replace("\n", "")).get('geodiff_schema')
-
-    geodiff.schema('sqlite', '', base_path, tmp_file.name)
-    with open(tmp_file.name, encoding="utf-8") as f:
-        data = f.read()
-        local_schema = json.loads(data.replace("\n", "")).get('geodiff_schema')
-
-    os.unlink(tmp_file.name)
 
     return same_schema(local_schema, base_schema)
 

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -920,11 +920,13 @@ def has_schema_change(mp, layer):
     tmp_file.close()
     geodiff.schema('sqlite', '', local_path, tmp_file.name)
     with open(tmp_file.name, encoding="utf-8") as f:
-        base_schema = json.load(f).get('geodiff_schema')
+        data = f.read()
+        base_schema = json.loads(data.replace("\n", "")).get('geodiff_schema')
 
     geodiff.schema('sqlite', '', base_path, tmp_file.name)
     with open(tmp_file.name, encoding="utf-8") as f:
-        local_schema = json.load(f).get('geodiff_schema')
+        data = f.read()
+        local_schema = json.loads(data.replace("\n", "")).get('geodiff_schema')
 
     os.unlink(tmp_file.name)
 

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -33,6 +33,7 @@ class Warning(Enum):
     ATTACHMENT_EXPRESSION_PATH = 11
     ATTACHMENT_HYPERLINK = 12
     DATABASE_SCHEMA_CHANGE = 13
+    INCORRECT_FIELD_NAME = 14
 
 
 class MultipleLayersWarning:
@@ -86,6 +87,7 @@ class MerginProjectValidator(object):
         self.check_offline()
         self.check_attachment_widget()
         self.check_db_schema()
+        self.check_field_names()
 
         return self.issues
 
@@ -217,6 +219,18 @@ class MerginProjectValidator(object):
                 if not has_change:
                     self.issues.append(SingleLayerWarning(lid, Warning.DATABASE_SCHEMA_CHANGE))
 
+    def check_field_names(self):
+        for lid, layer in self.layers.items():
+            if lid not in self.editable:
+                continue
+            dp = layer.dataProvider()
+            if dp.storageType() == "GPKG":
+                fields = layer.fields()
+                for f in fields:
+                    if '\n' in f.name():
+                        self.issues.append(SingleLayerWarning(lid, Warning.INCORRECT_FIELD_NAME))
+
+
 
 def warning_display_string(warning_id):
     """Returns a display string for a corresponing warning
@@ -248,3 +262,5 @@ def warning_display_string(warning_id):
         return "Attachment widget uses hyperlink"
     elif warning_id == Warning.DATABASE_SCHEMA_CHANGE:
         return "Database schema was changed"
+    elif warning_id == Warning.INCORRECT_FIELD_NAME:
+        return "Field names contain line-break characters"

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -1,4 +1,5 @@
 import os
+import re
 from enum import Enum
 from collections import defaultdict
 
@@ -17,6 +18,8 @@ from .utils import (
     QGIS_DB_PROVIDERS,
     QGIS_NET_PROVIDERS
 )
+
+INVALID_CHARS = re.compile("[\\\/\(\)\[\]\{\}\"\n\r]")
 
 
 class Warning(Enum):
@@ -227,7 +230,7 @@ class MerginProjectValidator(object):
             if dp.storageType() == "GPKG":
                 fields = layer.fields()
                 for f in fields:
-                    if '\n' in f.name():
+                    if INVALID_CHARS.search(f.name()):
                         self.issues.append(SingleLayerWarning(lid, Warning.INCORRECT_FIELD_NAME))
 
 


### PR DESCRIPTION
This is a workaround for the case when field or table names contain caret return character and cause broken JSON output from geodiff.