### PR TITLE
Relation validations

### DIFF
--- a/Mergin/test/test_validations.py
+++ b/Mergin/test/test_validations.py
@@ -56,5 +56,6 @@ class test_validations(unittest.TestCase):
         self.assertFalse(equal)
         self.assertEqual(msg, "Definition of 'date' field in 'Survey_points' table is not the same")
 
+
 if __name__ == '__main__':
     nose2.main()

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -935,7 +935,6 @@ def has_schema_change(mp, layer):
     base_schema = get_schema(base_path)
     local_schema = get_schema(local_path)
 
-
     # need to invert bool as same_schema returns True if there are no
     # chnages, while has_schema_change should return False in this case
     is_same, msg = same_schema(local_schema, base_schema)
@@ -1012,21 +1011,18 @@ def get_primary_keys(layer):
     if "|" in layer.publicSource():
         table_name = layer.publicSource().split("|")[1].split("=")[1]
 
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.close()
-    geodiff.schema('sqlite', '', file_path, tmp_file.name)
-    with open(tmp_file.name, encoding="utf-8") as f:
-        data = f.read()
-        schema = json.loads(data.replace("\n", "")).get("geodiff_schema")
-    os.unlink(tmp_file.name)
+    schema = get_schema(file_path)
 
     table = next((t for t in schema if t["table"] == table_name), None)
     if table:
         cols = [c["name"] for c in table["columns"] if "primary_key" in c]
         return cols
 
+
 def test_server_connection(url, username, password):
     """
+    Test connection to Mergin server. This includes check for valid server URL
+    and user credentials correctness.
     """
     err_msg = validate_mergin_url(url)
     if err_msg:

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1016,7 +1016,8 @@ def get_primary_keys(layer):
     tmp_file.close()
     geodiff.schema('sqlite', '', file_path, tmp_file.name)
     with open(tmp_file.name, encoding="utf-8") as f:
-        schema = json.load(f).get('geodiff_schema')
+        data = f.read()
+        schema = json.loads(data.replace("\n", "")).get("geodiff_schema")
     os.unlink(tmp_file.name)
 
     table = next((t for t in schema if t["table"] == table_name), None)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -929,11 +929,17 @@ def has_schema_change(mp, layer):
     f_name = os.path.split(local_path)[1]
     base_path = mp.fpath_meta(f_name)
 
+    if not os.path.exists(base_path):
+        return False, "No schema changes"
+
     base_schema = get_schema(base_path)
     local_schema = get_schema(local_path)
 
 
-    return same_schema(local_schema, base_schema)
+    # need to invert bool as same_schema returns True if there are no
+    # chnages, while has_schema_change should return False in this case
+    is_same, msg = same_schema(local_schema, base_schema)
+    return not is_same, msg
 
 
 def same_schema(schema_a, schema_b):

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -94,6 +94,7 @@ class MerginProjectValidator(object):
         self.check_attachment_widget()
         self.check_db_schema()
         self.check_project_relations()
+        self.check_value_relation()
         self.check_field_names()
 
         return self.issues
@@ -252,16 +253,15 @@ class MerginProjectValidator(object):
                 ws = layer.editorWidgetSetup(i)
                 if ws and ws.type() == "ValueRelation":
                     cfg = ws.config()
-                    child_layer = next((l for l in layers.values() if l.source() == cfg["LayerSource"]), None)
+                    child_layer = next((l for l in self.layers.values() if l.source() == cfg["LayerSource"]), None)
                     if child_layer is None:
                         self.issues.append(SingleLayerWarning(lid, Warning.VALUE_RELATION_LAYER_MISSED))
 
                     # check that "key" field does not have duplicated values
-                    idx = layer.fields().indexFromName(cfg["Key"])
-                    self._check_field_unique(layer, [idx])
-
-                    # check that "key" field is not a primary key
-                    self._check_primary_keys(parent_layer, [idx])
+                    # and is not a primary key
+                    idx = child_layer.fields().indexFromName(str(cfg["Key"]))
+                    self._check_field_unique(child_layer, [idx])
+                    self._check_primary_keys(child_layer, [idx])
 
     def _check_field_unique(self, layer, fields):
         feature_count = layer.dataProvider().featureCount()

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -219,7 +219,7 @@ class MerginProjectValidator(object):
             dp = layer.dataProvider()
             if dp.storageType() == "GPKG":
                 has_change, msg = has_schema_change(self.mp, layer)
-                if not has_change:
+                if has_change:
                     self.issues.append(SingleLayerWarning(lid, Warning.DATABASE_SCHEMA_CHANGE))
 
     def check_field_names(self):

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -190,7 +190,7 @@ class MerginProjectValidator(object):
             self.issues.append(w)
 
     def check_attachment_widget(self):
-        """Check if attachment widget configured correctly."""
+        """Check if attachment widget is configured correctly."""
         for lid, layer in self.layers.items():
             if lid not in self.editable:
                 continue


### PR DESCRIPTION
Adds more validations, this time for relations:

- check that project relations and value relations don't use GPKG primary key column as referenced/referencing column
- check that referenced/referencing columns contain only unique values
- check that referenced layer in value relation present in the QGIS project.

Fixes #291 and #296.