### PR TITLE
add photo quality setting to mergin project properties

### DIFF
--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -1,9 +1,10 @@
 import json
 import os
 from qgis.PyQt import uic
-from qgis.gui import QgsOptionsWidgetFactory, QgsOptionsPageWidget
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QFileDialog
+from qgis.core import QgsProject
+from qgis.gui import QgsOptionsWidgetFactory, QgsOptionsPageWidget
 from .utils import icon_path, mergin_project_local_path
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_project_config.ui')
@@ -28,6 +29,16 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
     def __init__(self, parent=None):
         QgsOptionsPageWidget.__init__(self, parent)
         self.setupUi(self)
+
+        self.cmb_photo_quality.addItem("Original", 0)
+        self.cmb_photo_quality.addItem("High", 1)
+        self.cmb_photo_quality.addItem("Medium", 2)
+        self.cmb_photo_quality.addItem("Low", 3)
+
+        quality, ok = QgsProject.instance().readEntry("Mergin", "PhotoQuality")
+        idx = self.cmb_photo_quality.findData(quality) if ok else 0
+        self.cmb_photo_quality.setCurrentIndex(idx if idx > 0 else 0)
+
         self.local_project_dir = mergin_project_local_path()
 
         if self.local_project_dir:
@@ -70,4 +81,5 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
             json.dump(config, f, indent=2)
 
     def apply(self):
+        QgsProject.instance().writeEntry("Mergin", "PhotoQuality", self.cmb_photo_quality.currentData())
         self.save_config_file()

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -31,9 +31,9 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         self.setupUi(self)
 
         self.cmb_photo_quality.addItem("Original", 0)
-        self.cmb_photo_quality.addItem("High (approx. 5 Mb)", 1)
-        self.cmb_photo_quality.addItem("Medium (approx. 3 Mb)", 2)
-        self.cmb_photo_quality.addItem("Low (approx. 1 Mb)", 3)
+        self.cmb_photo_quality.addItem("High (approx. 2-4 Mb)", 1)
+        self.cmb_photo_quality.addItem("Medium (approx. 1-2 Mb)", 2)
+        self.cmb_photo_quality.addItem("Low (approx. 0.5 Mb)", 3)
 
         quality, ok = QgsProject.instance().readEntry("Mergin", "PhotoQuality")
         idx = self.cmb_photo_quality.findData(quality) if ok else 0

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -31,9 +31,9 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         self.setupUi(self)
 
         self.cmb_photo_quality.addItem("Original", 0)
-        self.cmb_photo_quality.addItem("High", 1)
-        self.cmb_photo_quality.addItem("Medium", 2)
-        self.cmb_photo_quality.addItem("Low", 3)
+        self.cmb_photo_quality.addItem("High (approx. 5 Mb)", 1)
+        self.cmb_photo_quality.addItem("Medium (approx. 3 Mb)", 2)
+        self.cmb_photo_quality.addItem("Low (approx. 1 Mb)", 3)
 
         quality, ok = QgsProject.instance().readEntry("Mergin", "PhotoQuality")
         idx = self.cmb_photo_quality.findData(quality) if ok else 0

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -10,23 +10,13 @@
     <x>0</x>
     <y>0</y>
     <width>495</width>
-    <height>241</height>
+    <height>242</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Create Mergin Project</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="1">
-    <widget class="QComboBox" name="cmb_photo_quality"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Photo quality</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="selective_sync_group">
      <property name="title">
@@ -36,7 +26,13 @@
       <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>This is configuration for selective sync for Input in Mergin project.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for Input in Mergin project. Check our &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt; to learn more about this feature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -80,6 +76,38 @@
         </property>
         <property name="text">
          <string>Enable selective sync for Input</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Photo quality</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Photo quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cmb_photo_quality"/>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>This option is used by Input when adding pictures to the project (taken from camera or using existing picture from gallery).</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QWidget</class>
+ <class>Mergin</class>
  <widget class="QWidget" name="Mergin">
   <property name="enabled">
    <bool>true</bool>
@@ -9,98 +9,95 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>501</width>
-    <height>148</height>
+    <width>495</width>
+    <height>241</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Create Mergin Project</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QGroupBox" name="selective_sync_group">
-       <property name="title">
-        <string>Selective sync</string>
-       </property>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="cmb_photo_quality"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Photo quality</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QGroupBox" name="selective_sync_group">
+     <property name="title">
+      <string>Selective sync</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="label">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>30</y>
-          <width>451</width>
-          <height>17</height>
-         </rect>
-        </property>
         <property name="text">
          <string>This is configuration for selective sync for Input in Mergin project.</string>
         </property>
        </widget>
-       <widget class="QCheckBox" name="chk_sync_enabled">
+      </item>
+      <item row="3" column="2">
+       <widget class="QLineEdit" name="edit_sync_dir">
         <property name="enabled">
          <bool>true</bool>
         </property>
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>60</y>
-          <width>401</width>
-          <height>23</height>
-         </rect>
+        <property name="minimumSize">
+         <size>
+          <width>175</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>Select sync directory</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QToolButton" name="btn_get_sync_dir">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_sync_dir">
+        <property name="text">
+         <string> Only apply for folder: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="4">
+       <widget class="QCheckBox" name="chk_sync_enabled">
+        <property name="enabled">
+         <bool>true</bool>
         </property>
         <property name="text">
          <string>Enable selective sync for Input</string>
         </property>
        </widget>
-       <widget class="QWidget" name="layoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>80</y>
-          <width>461</width>
-          <height>41</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="select_dir_layout">
-         <item>
-          <widget class="QLabel" name="label_sync_dir">
-           <property name="text">
-            <string> Only apply for folder: </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="edit_sync_dir">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>175</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="placeholderText">
-            <string>Select sync directory</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="btn_get_sync_dir">
-           <property name="text">
-            <string>...</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </widget>
-     </item>
-    </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for Input in Mergin project. Check our &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt; to learn more about this feature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is configuration for selective sync for Input in Mergin project. With selective sync enabled Input will not download photos from other surveyors to make synchronisation faster. Check out more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/selective_sync/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>


### PR DESCRIPTION
Adds dropdown to Mergin project settings dialog with the following options: "Original", "High", "Medium" and "Low". By default "Original" setting is used to keep backward compatibility.

![зображення](https://user-images.githubusercontent.com/776954/164393588-7f814fa6-ab28-4822-94c8-f2db0c4abe1a.png)

Refs lutraconsulting/input/issues/841.

