### PR TITLE
Visualisation of local changes

### DIFF
--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -1,0 +1,497 @@
+import os
+import json
+import base64
+import sqlite3
+import tempfile
+import xml.etree.ElementTree as ET
+
+from qgis.PyQt.QtCore import (
+    QVariant
+)
+
+from qgis.PyQt.QtGui import (
+    QColor
+)
+
+from qgis.core import (
+    QgsVectorLayer,
+    QgsFeature,
+    QgsGeometry,
+    QgsFields,
+    QgsField,
+    QgsProject,
+    QgsLayerTreeLayer,
+    QgsConditionalStyle,
+    QgsSymbolLayerUtils,
+    QgsMarkerSymbol,
+    QgsLineSymbol,
+    QgsFillSymbol,
+    QgsRuleBasedRenderer,
+    QgsWkbTypes,
+    QgsProjectArchive
+)
+
+from .utils import (
+    pygeodiff,
+    get_schema
+)
+
+CHANGES_GROUP = "Mergin local changes"
+
+geodiff = pygeodiff.GeoDiff()
+geodiff.set_maximum_logger_level(10)
+
+
+class ColumnSchema:
+    """Describes GPKG table column"""
+    def __init__(self, name, datatype, pkey):
+        self.name = name
+        self.datatype = datatype
+        self.pkey = pkey
+
+    def __repr__(self):
+        return f'<ColumnSchema {self.name} ({self.datatype})>'
+
+
+class TableSchema:
+    """Describes GPKG table"""
+    def __init__(self, name, columns):
+        self.name = name
+        self.columns = columns
+
+    def geometry_column_index(self):
+        """Returns index of the geometry column or -1 if it does not exist"""
+        for i, col in enumerate(self.columns):
+            if col.datatype == 'geometry':
+                return i
+        return -1
+
+    def __repr__(self):
+        return f'<TableSchema {self.name}>'
+
+
+def old_value_for_column_by_index(entry_changes, i):
+    """Retrieve previous (old) column value for given column index"""
+    for ch in entry_changes:
+        if ch['column'] == i:
+            return ch['old']
+    raise ValueError("Expected value for column, but missing")
+
+
+def get_row_from_db(db_conn, schema_table, entry_changes):
+    """
+    Fetches a single row from DB's table based on the values of pkeys
+    in changeset entry
+    """
+    c = db_conn.cursor()
+    where_bits = []
+    for i, col in enumerate(schema_table.columns):
+        if col.pkey:
+            where_bits.append("{} = {}".format(col.name, old_value_for_column_by_index(entry_changes, i)))
+
+    c.execute('SELECT * FROM {} WHERE {}'.format(schema_table.name, " AND ".join(where_bits)))
+    return c.fetchone()
+
+
+def parse_gpkg_geom_encoding(wkb_with_gpkg_hdr):
+    """Parse header of GPKG WKB and return WKB geometry"""
+    flag_byte = wkb_with_gpkg_hdr[3]
+    envelope_byte = (flag_byte & 14) >> 1
+    envelope_size = {0: 0, 1: 32, 2: 48, 3: 48, 4: 64 }[envelope_byte]
+    hdr_size = 8 + envelope_size
+    wkb = wkb_with_gpkg_hdr[hdr_size:]
+    return wkb
+
+
+def parse_db_schema(db_file):
+    """Parse GPKG file schema and return map of tables
+    """
+    schema_json = get_schema(db_file)
+
+    tables = {}  # key: name, value: TableSchema
+    for tbl in schema_json:
+        columns = []
+        for col in tbl['columns']:
+            columns.append(ColumnSchema(col['name'], col['type'], 'primary_key' in col and col['primary_key']))
+
+        tables[tbl['table']] = TableSchema(tbl['table'], columns)
+    return tables
+
+
+def parse_diff(diff_file):
+    """
+    Parse binary GeoDiff changeset and return map of changes per table
+    as follows
+
+    key: table name, value: list of tuples (type, changes)
+    """
+    tmp_file = tempfile.NamedTemporaryFile(delete=False)
+    tmp_file.close()
+
+    geodiff.list_changes(diff_file, tmp_file.name)
+    with open(tmp_file.name, encoding="utf-8") as f:
+        diff_json = json.load(f)
+    os.unlink(tmp_file.name)
+
+    diff_entries = diff_json['geodiff']
+
+    # group diff entries by tables
+    diff_tables = {}    # key: table name, value: list of tuples (type, changes)
+    for diff_entry in diff_entries:
+        entry_table = diff_entry['table']
+        entry_type = diff_entry['type']
+        entry_changes = diff_entry['changes']
+
+        if entry_table not in diff_tables:
+            diff_tables[entry_table] = []
+        diff_tables[entry_table].append( (entry_type, entry_changes) )
+
+    return diff_tables
+
+
+def create_field_list(schema_table):
+    """
+    Creates QgsFields object from table schema as well as a mapping
+    between table columns and fields indices
+    """
+    columns_to_fields = {}  # some columns (e.g. geometry) may be skipped
+
+    fields = QgsFields()
+    for i, column in enumerate(schema_table.columns):
+        if column.datatype == 'integer':
+            t = QVariant.Int
+        elif column.datatype == 'text':
+            t = QVariant.String
+        elif column.datatype == 'double':
+            t = QVariant.Double
+        elif column.datatype == 'date':
+            t = QVariant.Date
+        elif column.datatype == 'datetime':
+            t = QVariant.DateTime
+        elif column.datatype == 'boolean':
+            t = QVariant.Bool
+        elif column.datatype == 'blob':
+            t = QVariant.QByteArray
+        elif column.datatype == 'geometry':
+            continue
+        else:
+            raise ValueError(f"Unknow column type '{column.datatype}' for column '{column.name}'")
+        columns_to_fields[i] = fields.count()
+        f = QgsField(column.name, t)
+        fields.append(f)
+
+    fields.append(QgsField("geometry", QVariant.String))
+    old_fields = QgsFields()
+    for f in fields:
+        old_fields.append(QgsField("_old_" + f.name(), f.type()))
+    fields.extend(old_fields)
+    fields.append(QgsField("_op", QVariant.String))
+
+    return fields, columns_to_fields
+
+
+def diff_table_to_features(diff_table, schema_table, fields, cols_to_flds, db_conn=None):
+    """
+    Converts a diff into list of QgsFeatures.
+
+    Input is list of tuples (type, changes) where type is 'insert'/'update'/'delete'
+    and changes is a list of dicts. Each dict with 'column', 'old', 'new' (old/new optional)
+    """
+    column_names = [column.name for column in schema_table.columns]
+    features = []
+
+    fld_geometry_idx = fields.indexOf('geometry')
+    fld_old_offset = fld_geometry_idx + 1
+
+    geom_col_index = schema_table.geometry_column_index()
+
+    for entry_type, entry_changes in diff_table:
+        f = QgsFeature(fields)
+        row = [None for i in range(len(column_names))]
+
+        f["_op"] = entry_type
+
+        # try to fill in unchanged columns from the database
+        if entry_type == 'update' and db_conn is not None:
+            db_row = get_row_from_db(db_conn, schema_table, entry_changes)
+
+            for i in range(len(db_row)):
+                if i == geom_col_index:
+                    wkb = parse_gpkg_geom_encoding(db_row[i])
+                    g = QgsGeometry()
+                    g.fromWkb(wkb)
+                    f.setGeometry(g)
+
+                    f[fld_geometry_idx] = g.asWkt()
+                    f[fld_geometry_idx + fld_old_offset] = g.asWkt()
+                    continue
+                else:
+                    f[cols_to_flds[i]] = db_row[i]
+                    f[cols_to_flds[i] + fld_old_offset] = db_row[i]
+
+        for entry_change in entry_changes:
+            i = entry_change['column']
+            if 'new' in entry_change:
+                value = entry_change['new']
+            elif 'old' in entry_change:
+                value = entry_change['old']
+            else:
+                value = '?'
+
+            if i == geom_col_index:
+                wkb_with_gpkg_hdr = base64.decodebytes(value.encode('ascii'))
+                wkb = parse_gpkg_geom_encoding(wkb_with_gpkg_hdr)
+                g = QgsGeometry()
+                g.fromWkb(wkb)
+                f.setGeometry(g)
+
+                f[fld_geometry_idx] = g.asWkt()
+            else:
+                f[cols_to_flds[i]] = value
+
+        features.append(f)
+
+    return features
+
+
+def get_table_name(layer):
+    """"Returns name of the GPKG table name for the given vector layer"""
+    table_name = ''
+    if 'layername' not in layer.source():
+        sublayers = layer.dataProvider().subLayers()
+        table_name = sublayers[0].split('!!::!!')[1]
+    else:
+        table_name = layer.source().partition('|layername=')[2]
+
+    return table_name
+
+
+def get_local_changes(db_file, mp):
+    """Creates changeset containing local changes in the given GPKG file."""
+    f_name = os.path.split(db_file)[1]
+    base_path = mp.fpath_meta(f_name)
+
+    if not os.path.exists(base_path):
+        return None
+
+    diff_file = tempfile.NamedTemporaryFile(delete=False)
+    diff_file.close()
+
+    geodiff.create_changeset(base_path, db_file, diff_file.name)
+    return diff_file.name
+
+
+def make_local_changes_layer(mp, layer):
+    layer_path = layer.source().split("|")[0]
+    diff_path = get_local_changes(layer_path, mp)
+
+    if diff_path is None:
+        return None, f"Failed to retrieve changes, as there is no base file for layer '{layer.name()}'"
+
+    db_schema = parse_db_schema(layer_path)
+    diff = parse_diff(diff_path)
+    table_name = get_table_name(layer)
+
+    if not diff or table_name not in diff.keys():
+        return None, f"No local changes found in layer '{layer.name()}'"
+
+    fields, cols_to_fields = create_field_list(db_schema[table_name])
+
+    db_conn = None  # no ref. db
+    db_conn = sqlite3.connect(layer_path)
+
+    features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, cols_to_fields, db_conn)
+
+    # create diff layer
+    vl = QgsVectorLayer(f"{QgsWkbTypes.displayString(layer.wkbType())}?crs={layer.sourceCrs().authid()}",
+                        f"{layer.name()}-diff", "memory")
+    if not vl.isValid():
+        return None, f"Failed to create memory layer for local changes"
+
+    vl.dataProvider().addAttributes(fields)
+    vl.updateFields()
+    vl.dataProvider().addFeatures(features)
+
+    style_diff_layer(vl, db_schema[table_name])
+    return vl, ''
+
+
+def add_diff_layer_to_canvas(layer):
+    """Adds diff layer to the QGIS map canvas.
+
+    Layer added to the "Local changes" group (created if not exists).
+    If layer with the same name already exists it will be deleted and
+    new layer added instead of it.
+    """
+    layers = QgsProject.instance().mapLayersByName(layer.name())
+    if layers:
+        QgsProject.instance().removeMapLayers([l.id() for l in layers])
+
+    root = QgsProject.instance().layerTreeRoot()
+    group = root.findGroup(CHANGES_GROUP)
+    if not group:
+        group = root.insertGroup(0, CHANGES_GROUP)
+
+    QgsProject.instance().addMapLayer(layer, False)
+    node_layer = QgsLayerTreeLayer(layer)
+    group.insertChildNode(0, node_layer)
+    group.setExpanded(True)
+
+
+def style_diff_layer(layer, schema_table):
+    """Apply conditional styling and symbology to diff layer"""
+    ### setup conditional styles!
+    st = layer.conditionalStyles()
+    color_red = QColor('#ffdce0')
+    color_green = QColor('#dcffe4')
+    color_yellow = QColor('#fff5b1')
+
+    # full row for insert / delete
+    cs_insert = QgsConditionalStyle()
+    cs_insert.setName("insert")
+    cs_insert.setRule("_op = 'insert'")
+    cs_insert.setBackgroundColor(color_green)
+    cs_delete = QgsConditionalStyle()
+    cs_delete.setName("delete")
+    cs_delete.setRule("_op = 'delete'")
+    cs_delete.setBackgroundColor(color_red)
+    st.setRowStyles([cs_insert, cs_delete])
+
+    # field style for each updated field
+    for column in schema_table.columns:
+        if column.datatype == 'geometry':
+            col_name = 'geometry'
+        else:
+            col_name = column.name
+        cs = QgsConditionalStyle()
+        cs.setName("update")
+        cs.setRule(f'"{col_name}" != "_old_{col_name}"')
+        cs.setBackgroundColor(color_yellow)
+        st.setFieldStyles(col_name, [cs])
+
+    # set up which fields are shown in the attribute table
+    cfg = layer.attributeTableConfig()
+    flds = layer.fields()
+    for i, fld in enumerate(flds):
+        if fld.name().startswith("_old_") or fld.name() == "_op":
+            cfg.setColumnHidden(i, True)
+    layer.setAttributeTableConfig(cfg)
+
+    # set up styling of the layer
+    darker_factor = 150
+    if layer.geometryType() == QgsWkbTypes.PointGeometry:
+        point_symbol_base = {
+            'name': 'circle',
+            'outline_style': 'solid',
+            'outline_width': '0.4',
+            'outline_width_unit': 'MM',
+            'size': '2',
+            'size_unit': 'MM',
+        }
+        point_symbol_insert = dict(point_symbol_base)
+        point_symbol_insert['color'] = QgsSymbolLayerUtils.encodeColor(color_green)
+        point_symbol_insert['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_green.darker(darker_factor))
+        point_symbol_update = dict(point_symbol_base)
+        point_symbol_update['color'] = QgsSymbolLayerUtils.encodeColor(color_yellow)
+        point_symbol_update['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_yellow.darker(darker_factor))
+        point_symbol_delete = dict(point_symbol_base)
+        point_symbol_delete['color'] = QgsSymbolLayerUtils.encodeColor(color_red)
+        point_symbol_delete['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_red.darker(darker_factor))
+
+        root_rule = QgsRuleBasedRenderer.Rule(None)
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsMarkerSymbol.createSimple(point_symbol_insert), 0, 0, "_op = 'insert'", "Insert"))
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsMarkerSymbol.createSimple(point_symbol_update), 0, 0, "_op = 'update'", "Update"))
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsMarkerSymbol.createSimple(point_symbol_delete), 0, 0, "_op = 'delete'", "Delete"))
+        r = QgsRuleBasedRenderer(root_rule)
+        layer.setRenderer(r)
+    elif layer.geometryType() == QgsWkbTypes.LineGeometry:
+        line_symbol_base = {
+            'capstyle': 'square',
+            'joinstyle': 'bevel',
+            'line_style': 'solid',
+            'line_width': '0.26',
+            'line_width_unit': 'MM',
+        }
+        line_symbol_insert = dict(point_symbol_base)
+        line_symbol_insert['line_color'] = QgsSymbolLayerUtils.encodeColor(color_green)
+        line_symbol_update = dict(point_symbol_base)
+        line_symbol_update['line_color'] = QgsSymbolLayerUtils.encodeColor(color_yellow)
+        line_symbol_delete = dict(point_symbol_base)
+        line_symbol_delete['line_color'] = QgsSymbolLayerUtils.encodeColor(color_red)
+
+        root_rule = QgsRuleBasedRenderer.Rule(None)
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsLineSymbol.createSimple(line_symbol_insert), 0, 0, "_op = 'insert'", "Insert"))
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsLineSymbol.createSimple(line_symbol_update), 0, 0, "_op = 'update'", "Update"))
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsLineSymbol.createSimple(line_symbol_delete), 0, 0, "_op = 'delete'", "Delete"))
+        r = QgsRuleBasedRenderer(root_rule)
+        layer.setRenderer(r)
+    elif layer.geometryType() == QgsWkbTypes.PolygonGeometry:
+        fill_symbol_base = {
+            'joinstyle': 'bevel',
+            'style': 'solid',
+            'outline_style': 'solid',
+            'outline_width': '0.26',
+            'outline_width_unit': 'MM',
+        }
+        fill_symbol_insert = dict(point_symbol_base)
+        fill_symbol_insert['color'] = QgsSymbolLayerUtils.encodeColor(color_green)
+        fill_symbol_insert['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_green.darker(darker_factor))
+        fill_symbol_update = dict(point_symbol_base)
+        fill_symbol_update['color'] = QgsSymbolLayerUtils.encodeColor(color_yellow)
+        fill_symbol_update['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_yellow.darker(darker_factor))
+        fill_symbol_delete = dict(point_symbol_base)
+        fill_symbol_delete['color'] = QgsSymbolLayerUtils.encodeColor(color_red)
+        fill_symbol_delete['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_red.darker(darker_factor))
+
+        root_rule = QgsRuleBasedRenderer.Rule(None)
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsFillSymbol.createSimple(fill_symbol_insert), 0, 0, "_op = 'insert'", "Insert"))
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsFillSymbol.createSimple(fill_symbol_update), 0, 0, "_op = 'update'", "Update"))
+        root_rule.appendChild(QgsRuleBasedRenderer.Rule(QgsFillSymbol.createSimple(fill_symbol_delete), 0, 0, "_op = 'delete'", "Delete"))
+        r = QgsRuleBasedRenderer(root_rule)
+        layer.setRenderer(r)
+
+
+def cleanup_project(diff_layers):
+    """Remove group and diff layers from the project"""
+
+    arc = QgsProjectArchive()
+    xml = None
+    if QgsProject.instance().isZipped():
+        arc.unzip(QgsProject.instance().fileName())
+        xml = ET.parse(arc.projectFile())
+    else:
+        xml = ET.parse(QgsProject.instance().fileName())
+
+    root = xml.getroot()
+
+    # drop any reference to the group
+    elements = root.findall(f".//*[@name='{CHANGES_GROUP}']")
+    parents = root.findall(f".//*[@name='{CHANGES_GROUP}']/..")
+    for i, p in enumerate(parents):
+        p.remove(elements[i])
+
+    # drop layer-related elements
+    for lid in diff_layers:
+        # <layer> and <layer-setting> items
+        elements = root.findall(f".//*[@id='{lid}']")
+        parents = root.findall(f".//*[@id='{lid}']/..")
+        for i, p in enumerate(parents):
+            p.remove(elements[i])
+
+        # <maplayer> item
+        elements = root.findall(f".//maplayer/*[.='{lid}']/..")
+        parents = root.findall(f".//maplayer/*[.='{lid}']/../..")
+        for i, p in enumerate(parents):
+            p.remove(elements[i])
+
+        # <layer> item
+        elements = root.findall(f".//*[.='{lid}']")
+        parents = root.findall(f".//*[.='{lid}']/..")
+        for i, p in enumerate(parents):
+            p.remove(elements[i])
+
+    if QgsProject.instance().isZipped():
+        xml.write(arc.projectFile())
+        arc.zip(QgsProject.instance().fileName())
+    else:
+        xml.write(QgsProject.instance().fileName())

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -342,7 +342,7 @@ def style_diff_layer(layer, schema_table):
             col_name = column.name
         cs = QgsConditionalStyle()
         cs.setName("update")
-        cs.setRule(f'"_op" = "update" AND "{col_name}" IS NOT "_old_{col_name}"')
+        cs.setRule(f'"_op" = \'update\' AND "{col_name}" IS NOT "_old_{col_name}"')
         cs.setBackgroundColor(color_yellow)
         st.setFieldStyles(col_name, [cs])
 

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -303,7 +303,7 @@ def make_local_changes_layer(mp, layer):
 
     # create diff layer
     vl = QgsVectorLayer(f"{QgsWkbTypes.displayString(layer.wkbType())}?crs={layer.sourceCrs().authid()}",
-                        layer.name(), "memory")
+                        f"[Local changes] {layer.name()}", "memory")
     if not vl.isValid():
         return None, f"Failed to create memory layer for local changes"
 

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -492,7 +492,11 @@ def cleanup_project(diff_layers):
             p.remove(elements[i])
 
     if QgsProject.instance().isZipped():
-        xml.write(arc.projectFile())
+        with open(arc.projectFile(), 'wb') as f:
+            f.write("<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>".encode('utf8'))
+            xml.write(f)
         arc.zip(QgsProject.instance().fileName())
     else:
-        xml.write(QgsProject.instance().fileName())
+        with open(QgsProject.instance().fileName(), "wb") as f:
+            f.write("<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>".encode('utf8'))
+            xml.write(f)

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -283,6 +283,7 @@ def get_local_changes(db_file, mp):
 
 def make_local_changes_layer(mp, layer):
     layer_path = layer.source().split("|")[0]
+    base_file = mp.fpath_meta(os.path.split(layer_path)[1])
     diff_path = get_local_changes(layer_path, mp)
 
     if diff_path is None:
@@ -298,7 +299,7 @@ def make_local_changes_layer(mp, layer):
     fields, cols_to_fields = create_field_list(db_schema[table_name])
 
     db_conn = None  # no ref. db
-    db_conn = sqlite3.connect(layer_path)
+    db_conn = sqlite3.connect(base_file)
 
     features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, cols_to_fields, db_conn)
 
@@ -365,7 +366,7 @@ def style_diff_layer(layer, schema_table):
             col_name = column.name
         cs = QgsConditionalStyle()
         cs.setName("update")
-        cs.setRule(f'"{col_name}" != "_old_{col_name}"')
+        cs.setRule(f'"{col_name}" IS NOT "_old_{col_name}"')
         cs.setBackgroundColor(color_yellow)
         st.setFieldStyles(col_name, [cs])
 

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -342,7 +342,7 @@ def style_diff_layer(layer, schema_table):
             col_name = column.name
         cs = QgsConditionalStyle()
         cs.setName("update")
-        cs.setRule(f'"{col_name}" IS NOT "_old_{col_name}"')
+        cs.setRule(f'"_op" = "update" AND "{col_name}" IS NOT "_old_{col_name}"')
         cs.setBackgroundColor(color_yellow)
         st.setFieldStyles(col_name, [cs])
 

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -41,6 +41,8 @@ CHANGES_GROUP = "Mergin local changes"
 geodiff = pygeodiff.GeoDiff()
 geodiff.set_maximum_logger_level(10)
 
+diff_layers_list = []
+
 
 class ColumnSchema:
     """Describes GPKG table column"""

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -310,6 +310,7 @@ def make_local_changes_layer(mp, layer):
     vl.dataProvider().addAttributes(fields)
     vl.updateFields()
     vl.dataProvider().addFeatures(features)
+    vl.setName(f"{layer.name()} - diff")
 
     style_diff_layer(vl, db_schema[table_name])
     return vl, ''
@@ -386,14 +387,14 @@ def style_diff_layer(layer, schema_table):
             'capstyle': 'square',
             'joinstyle': 'bevel',
             'line_style': 'solid',
-            'line_width': '0.26',
+            'line_width': '0.46',
             'line_width_unit': 'MM',
         }
-        line_symbol_insert = dict(point_symbol_base)
+        line_symbol_insert = dict(line_symbol_base)
         line_symbol_insert['line_color'] = QgsSymbolLayerUtils.encodeColor(color_green)
-        line_symbol_update = dict(point_symbol_base)
+        line_symbol_update = dict(line_symbol_base)
         line_symbol_update['line_color'] = QgsSymbolLayerUtils.encodeColor(color_yellow)
-        line_symbol_delete = dict(point_symbol_base)
+        line_symbol_delete = dict(line_symbol_base)
         line_symbol_delete['line_color'] = QgsSymbolLayerUtils.encodeColor(color_red)
 
         root_rule = QgsRuleBasedRenderer.Rule(None)
@@ -410,13 +411,13 @@ def style_diff_layer(layer, schema_table):
             'outline_width': '0.26',
             'outline_width_unit': 'MM',
         }
-        fill_symbol_insert = dict(point_symbol_base)
+        fill_symbol_insert = dict(fill_symbol_base)
         fill_symbol_insert['color'] = QgsSymbolLayerUtils.encodeColor(color_green)
         fill_symbol_insert['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_green.darker(darker_factor))
-        fill_symbol_update = dict(point_symbol_base)
+        fill_symbol_update = dict(fill_symbol_base)
         fill_symbol_update['color'] = QgsSymbolLayerUtils.encodeColor(color_yellow)
         fill_symbol_update['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_yellow.darker(darker_factor))
-        fill_symbol_delete = dict(point_symbol_base)
+        fill_symbol_delete = dict(fill_symbol_base)
         fill_symbol_delete['color'] = QgsSymbolLayerUtils.encodeColor(color_red)
         fill_symbol_delete['outline_color'] = QgsSymbolLayerUtils.encodeColor(color_red.darker(darker_factor))
 

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -303,14 +303,13 @@ def make_local_changes_layer(mp, layer):
 
     # create diff layer
     vl = QgsVectorLayer(f"{QgsWkbTypes.displayString(layer.wkbType())}?crs={layer.sourceCrs().authid()}",
-                        f"{layer.name()}-diff", "memory")
+                        layer.name(), "memory")
     if not vl.isValid():
         return None, f"Failed to create memory layer for local changes"
 
     vl.dataProvider().addAttributes(fields)
     vl.updateFields()
     vl.dataProvider().addFeatures(features)
-    vl.setName(f"{layer.name()} - diff")
 
     style_diff_layer(vl, db_schema[table_name])
     return vl, ''
@@ -363,7 +362,7 @@ def style_diff_layer(layer, schema_table):
             'outline_style': 'solid',
             'outline_width': '0.4',
             'outline_width_unit': 'MM',
-            'size': '2',
+            'size': '5',
             'size_unit': 'MM',
         }
         point_symbol_insert = dict(point_symbol_base)
@@ -387,7 +386,7 @@ def style_diff_layer(layer, schema_table):
             'capstyle': 'square',
             'joinstyle': 'bevel',
             'line_style': 'solid',
-            'line_width': '0.46',
+            'line_width': '0.86',
             'line_width_unit': 'MM',
         }
         line_symbol_insert = dict(line_symbol_base)

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -1,7 +1,7 @@
 import os
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QSettings
 from qgis.PyQt.QtGui import QIcon, QColor
 from qgis.PyQt.QtWidgets import (
     QDialog,
@@ -40,6 +40,10 @@ class DiffViewerDialog(QDialog):
         self.ui = uic.loadUi(ui_file, self)
 
         QgsGui.instance().enableAutoGeometryRestore(self)
+        settings = QSettings()
+        state = settings.value("Mergin/changesViewerSplitterSize")
+        if state:
+            self.splitter.restoreState(state)
 
         btn_add_changes = QPushButton("Add to project")
         btn_add_changes.setIcon(QIcon(icon_path('file-plus.svg')))
@@ -68,7 +72,16 @@ class DiffViewerDialog(QDialog):
         self.create_tabs()
 
     def reject(self):
+        self.saveSplitterState()
         QDialog.reject(self)
+
+    def closeEvent(self, event):
+        self.saveSplitterState()
+        QDialog.closeEvent(self, event)
+
+    def saveSplitterState(self):
+        settings = QSettings()
+        settings.setValue("Mergin/changesViewerSplitterSize", self.splitter.saveState())
 
     def create_tabs(self):
         mp = MerginProject(QgsProject.instance().homePath())

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -104,7 +104,7 @@ class DiffViewerDialog(QDialog):
                 continue
 
             self.diff_layers.append(vl)
-            self.tab_bar.addTab(QgsIconUtils.iconForLayer(vl), vl.name())
+            self.tab_bar.addTab(QgsIconUtils.iconForLayer(vl), f"{layer.name()} ({vl.featureCount()})")
         self.tab_bar.setCurrentIndex(0)
 
     def toggle_project_layers(self, state):

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -24,7 +24,7 @@ from qgis.gui import (
     QgsAttributeTableModel,
     QgsAttributeTableFilterModel
 )
-from qgis.utils import iface
+from qgis.utils import iface, OverrideCursor
 
 from .mergin.merginproject import MerginProject
 from .diff import make_local_changes_layer
@@ -39,37 +39,38 @@ class DiffViewerDialog(QDialog):
         QDialog.__init__(self, parent)
         self.ui = uic.loadUi(ui_file, self)
 
-        QgsGui.instance().enableAutoGeometryRestore(self)
-        settings = QSettings()
-        state = settings.value("Mergin/changesViewerSplitterSize")
-        if state:
-            self.splitter.restoreState(state)
+        with OverrideCursor(Qt.WaitCursor):
+            QgsGui.instance().enableAutoGeometryRestore(self)
+            settings = QSettings()
+            state = settings.value("Mergin/changesViewerSplitterSize")
+            if state:
+                self.splitter.restoreState(state)
 
-        btn_add_changes = QPushButton("Add to project")
-        btn_add_changes.setIcon(QIcon(icon_path('file-plus.svg')))
-        self.ui.buttonBox.addButton(btn_add_changes, QDialogButtonBox.ActionRole)
-        menu = QMenu()
-        add_current_action = menu.addAction(QIcon(icon_path('file-plus.svg')), "Add current changes layer to project")
-        add_current_action.triggered.connect(self.add_current_to_project)
-        add_all_action = menu.addAction(QIcon(icon_path('folder-plus.svg')), "Add all changes layers to project")
-        add_all_action.triggered.connect(self.add_all_to_project)
-        btn_add_changes.setMenu(menu)
+            btn_add_changes = QPushButton("Add to project")
+            btn_add_changes.setIcon(QIcon(icon_path('file-plus.svg')))
+            self.ui.buttonBox.addButton(btn_add_changes, QDialogButtonBox.ActionRole)
+            menu = QMenu()
+            add_current_action = menu.addAction(QIcon(icon_path('file-plus.svg')), "Add current changes layer to project")
+            add_current_action.triggered.connect(self.add_current_to_project)
+            add_all_action = menu.addAction(QIcon(icon_path('folder-plus.svg')), "Add all changes layers to project")
+            add_all_action.triggered.connect(self.add_all_to_project)
+            btn_add_changes.setMenu(menu)
 
-        self.project_layers_checkbox.stateChanged.connect(self.toggle_project_layers)
+            self.project_layers_checkbox.stateChanged.connect(self.toggle_project_layers)
 
-        self.map_canvas.enableAntiAliasing(True)
-        self.map_canvas.setSelectionColor(QColor(Qt.cyan))
-        self.pan_tool = QgsMapToolPan(self.map_canvas)
-        self.map_canvas.setMapTool(self.pan_tool)
+            self.map_canvas.enableAntiAliasing(True)
+            self.map_canvas.setSelectionColor(QColor(Qt.cyan))
+            self.pan_tool = QgsMapToolPan(self.map_canvas)
+            self.map_canvas.setMapTool(self.pan_tool)
 
-        self.tab_bar.setUsesScrollButtons(True)
-        self.tab_bar.currentChanged.connect(self.diff_layer_changed)
+            self.tab_bar.setUsesScrollButtons(True)
+            self.tab_bar.currentChanged.connect(self.diff_layer_changed)
 
-        self.current_diff = None
-        self.diff_layers = []
-        self.filter_model = None
+            self.current_diff = None
+            self.diff_layers = []
+            self.filter_model = None
 
-        self.create_tabs()
+            self.create_tabs()
 
     def reject(self):
         self.saveSplitterState()

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -6,7 +6,7 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QDialog
 
 from qgis.core import QgsProject, QgsMapLayerProxyModel, QgsVectorLayerCache, QgsFeatureRequest
-from qgis.gui import QgsMapToolPan, QgsAttributeTableModel, QgsAttributeTableFilterModel
+from qgis.gui import QgsGui, QgsMapToolPan, QgsAttributeTableModel, QgsAttributeTableFilterModel
 from qgis.utils import iface
 
 from .mergin.merginproject import MerginProject
@@ -23,6 +23,8 @@ class DiffViewerDialog(QDialog):
     def __init__(self, parent=None):
         QDialog.__init__(self, parent)
         self.ui = uic.loadUi(ui_file, self)
+
+        QgsGui.instance().enableAutoGeometryRestore(self)
 
         self.map_canvas.enableAntiAliasing(True)
         self.pan_tool = QgsMapToolPan(self.map_canvas)

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -45,6 +45,9 @@ class DiffViewerDialog(QDialog):
             state = settings.value("Mergin/changesViewerSplitterSize")
             if state:
                 self.splitter.restoreState(state)
+            else:
+                height = max([self.map_canvas.minimumSizeHint().height(), self.attribute_table.minimumSizeHint().height()])
+                self.splitter.setSizes([height, height])
 
             btn_add_changes = QPushButton("Add to project")
             btn_add_changes.setIcon(QIcon(icon_path('file-plus.svg')))
@@ -73,14 +76,14 @@ class DiffViewerDialog(QDialog):
             self.create_tabs()
 
     def reject(self):
-        self.saveSplitterState()
+        self.save_splitter_state()
         QDialog.reject(self)
 
     def closeEvent(self, event):
-        self.saveSplitterState()
+        self.save_splitter_state()
         QDialog.closeEvent(self, event)
 
-    def saveSplitterState(self):
+    def save_splitter_state(self):
         settings = QSettings()
         settings.setValue("Mergin/changesViewerSplitterSize", self.splitter.saveState())
 

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -1,0 +1,97 @@
+import os
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QDialog
+
+from qgis.core import QgsProject, QgsMapLayerProxyModel, QgsVectorLayerCache, QgsFeatureRequest
+from qgis.gui import QgsMapToolPan, QgsAttributeTableModel, QgsAttributeTableFilterModel
+from qgis.utils import iface
+
+from .mergin.merginproject import MerginProject
+
+from .diff import make_local_changes_layer
+
+from .utils import icon_path
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_diff_viewer_dialog.ui')
+
+
+class DiffViewerDialog(QDialog):
+
+    def __init__(self, parent=None):
+        QDialog.__init__(self, parent)
+        self.ui = uic.loadUi(ui_file, self)
+
+        self.map_canvas.enableAntiAliasing(True)
+        self.pan_tool = QgsMapToolPan(self.map_canvas)
+        self.map_canvas.setMapTool(self.pan_tool)
+
+        self.diff_layer_cbo.setAllowEmptyLayer(True)
+        self.diff_layer_cbo.setFilters(QgsMapLayerProxyModel.HasGeometry)
+        self.diff_layer_cbo.setCurrentIndex(-1)
+        self.diff_layer_cbo.layerChanged.connect(self.diff_layer_changed)
+
+        self.add_to_project_btn.setIcon(QIcon(icon_path('file-plus.svg')))
+        self.add_to_project_btn.clicked.connect(self.add_diff_to_project)
+
+        self.project_layers_checkbox.stateChanged.connect(self.toggle_project_layers)
+
+        self.diff_layer = None
+        self.filter_model = None
+
+    def toggle_project_layers(self, state):
+        layers = self.collect_layers(state)
+        self.update_canvas(layers)
+
+    def update_canvas(self, layers):
+        self.map_canvas.setLayers(layers)
+        if layers:
+            self.map_canvas.setDestinationCrs(layers[0].crs())
+            extent = layers[0].extent()
+            d = min(extent.width(), extent.height())
+            if d == 0:
+                d = 1
+            extent = extent.buffered(d * 0.07)
+            self.map_canvas.setExtent(extent)
+        self.map_canvas.refresh()
+
+    def collect_layers(self, state):
+        if state == Qt.Checked:
+            layers = iface.mapCanvas().layers()
+        else:
+            layers = []
+
+        if self.diff_layer:
+            layers.insert(0, self.diff_layer)
+
+        return layers
+
+    def diff_layer_changed(self, layer):
+        base_layer = self.diff_layer_cbo.currentLayer()
+        if base_layer is not None:
+            mp = MerginProject(QgsProject.instance().homePath())
+            self.diff_layer, msg = make_local_changes_layer(mp, base_layer)
+            config = self.diff_layer.attributeTableConfig()
+
+            layer_cache = QgsVectorLayerCache(self.diff_layer, 1000, self)
+            layer_cache.setCacheGeometry(False)
+            table_model = QgsAttributeTableModel(layer_cache, self)
+            self.filter_model = QgsAttributeTableFilterModel(None, table_model, self)
+            table_model.setRequest(QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry).setLimit(100))
+            layer_cache.setParent(table_model)
+            table_model.setParent(self.filter_model)
+            self.attribute_table.setModel(self.filter_model)
+            table_model.loadLayer()
+            self.filter_model.setAttributeTableConfig(config)
+            self.attribute_table.setAttributeTableConfig(config)
+        else:
+            self.diff_layer = None
+
+        layers = self.collect_layers(self.project_layers_checkbox.checkState())
+        self.update_canvas(layers)
+
+    def add_diff_to_project(self):
+        if self.diff_layer:
+            QgsProject.instance().addMapLayer(self.diff_layer)

--- a/Mergin/diff_dialog.py
+++ b/Mergin/diff_dialog.py
@@ -138,18 +138,25 @@ class DiffViewerDialog(QDialog):
         if index > len(self.diff_layers):
             return
 
-        self.current_diff = self.diff_layers[index]
-        config = self.current_diff.attributeTableConfig()
+        self.map_canvas.setLayers([])
+        self.attribute_table.clearSelection()
 
-        layer_cache = QgsVectorLayerCache(self.current_diff, 1000, self)
-        layer_cache.setCacheGeometry(False)
-        table_model = QgsAttributeTableModel(layer_cache, self)
-        self.filter_model = QgsAttributeTableFilterModel(None, table_model, self)
-        table_model.setRequest(QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry).setLimit(100))
-        layer_cache.setParent(table_model)
-        table_model.setParent(self.filter_model)
+        self.current_diff = self.diff_layers[index]
+
+        self.layer_cache = QgsVectorLayerCache(self.current_diff, 1000)
+        self.layer_cache.setCacheGeometry(False)
+
+        self.table_model = QgsAttributeTableModel(self.layer_cache)
+        self.table_model.setRequest(QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry).setLimit(100))
+
+        self.filter_model = QgsAttributeTableFilterModel(self.map_canvas, self.table_model)
+
+        self.layer_cache.setParent(self.table_model)
+
         self.attribute_table.setModel(self.filter_model)
-        table_model.loadLayer()
+        self.table_model.loadLayer()
+
+        config = self.current_diff.attributeTableConfig()
         self.filter_model.setAttributeTableConfig(config)
         self.attribute_table.setAttributeTableConfig(config)
 

--- a/Mergin/images/tabler_icons/file-diff.svg
+++ b/Mergin/images/tabler_icons/file-diff.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-file-diff" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <desc>Download more icon variants from https://tabler-icons.io/i/file-diff</desc>
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  <line x1="12" y1="10" x2="12" y2="14" />
+  <line x1="10" y1="12" x2="14" y2="12" />
+  <line x1="10" y1="17" x2="14" y2="17" />
+</svg>
+
+

--- a/Mergin/images/tabler_icons/file-plus.svg
+++ b/Mergin/images/tabler_icons/file-plus.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-file-plus" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <desc>Download more icon variants from https://tabler-icons.io/i/file-plus</desc>
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+  <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  <line x1="12" y1="11" x2="12" y2="17" />
+  <line x1="9" y1="14" x2="15" y2="14" />
+</svg>
+
+

--- a/Mergin/images/tabler_icons/folder-plus.svg
+++ b/Mergin/images/tabler_icons/folder-plus.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-folder-plus" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <desc>Download more icon variants from https://tabler-icons.io/i/folder-plus</desc>
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M5 4h4l3 3h7a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-11a2 2 0 0 1 2 -2" />
+  <line x1="12" y1="10" x2="12" y2="16" />
+  <line x1="9" y1="13" x2="15" y2="13" />
+</svg>
+
+

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -386,6 +386,7 @@ class MerginPlugin:
                 continue
             add_diff_layer_to_canvas(vl)
             self.diff_layers.append(vl.id())
+            self.iface.messageBar().pushInfo('Mergin', 'Diff layer(s) were created and added the "Mergin local changes" group.')
 
     def cleanup_diffs(self):
         if self.diff_layers:

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -163,6 +163,7 @@ class MerginPlugin:
 
         # add layer context menu action for checking local changes
         self.action_show_changes = QAction("Show local changes", self.iface.mainWindow())
+        self.action_show_changes.setIcon(QIcon(icon_path("mm_icon_positive_no_padding.svg")))
         self.iface.addCustomActionForLayerType(self.action_show_changes, "", QgsMapLayer.VectorLayer, True)
         self.action_show_changes.triggered.connect(self.show_local_changes)
 

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -23,7 +23,6 @@ from qgis.core import (
     QgsProject,
     QgsMapLayer,
     QgsProviderRegistry,
-    QgsMessageLog,
     Qgis
 )
 from qgis.utils import iface
@@ -78,7 +77,6 @@ class MerginPlugin:
         self.mergin_proj_dir = None
         self.mc = None
         self.manager = None
-        self.dlg_diff_viewer = None
         self.provider = MerginProvider()
         self.toolbar = self.iface.addToolBar("Mergin Maps Toolbar")
         self.toolbar.setToolTip("Mergin Maps Toolbar")
@@ -362,14 +360,16 @@ class MerginPlugin:
             iface.messageBar().pushMessage("Mergin", "Current project is not a Mergin project.", Qgis.Warning)
             return
 
-        if self.dlg_diff_viewer is None:
-            self.dlg_diff_viewer = DiffViewerDialog()
-            self.dlg_diff_viewer.show()
-            self.dlg_diff_viewer.exec_()
-        else:
-            self.dlg_diff_viewer.showNormal()
-            self.dlg_diff_viewer.raise_()
-            self.dlg_diff_viewer.activateWindow()
+        mp = MerginProject(QgsProject.instance().homePath())
+        push_changes = mp.get_push_changes()
+        push_changes_summary = mp.get_list_of_push_changes(push_changes)
+        if not push_changes_summary:
+            iface.messageBar().pushMessage("Mergin", "No changes found in the project layers.", Qgis.Info)
+            return
+
+        dlg_diff_viewer = DiffViewerDialog()
+        dlg_diff_viewer.show()
+        dlg_diff_viewer.exec_()
 
 
 class MerginRemoteProjectItem(QgsDataItem):

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -344,6 +344,8 @@ class MerginPlugin:
             self.iface.removeToolBarIcon(action)
         del self.toolbar
 
+        self.iface.removeCustomActionForLayerType(self.action_show_changes)
+
         self.iface.unregisterProjectPropertiesWidgetFactory(self.mergin_project_config_factory)
         QgsApplication.processingRegistry().removeProvider(self.provider)
 

--- a/Mergin/processing/algs/create_diff.py
+++ b/Mergin/processing/algs/create_diff.py
@@ -91,7 +91,7 @@ class CreateDiff(QgsProcessingAlgorithm):
             raise QgsProcessingException("Selected layer does not belong to the selected Mergin project.")
 
         if layer.dataProvider().storageType() != "GPKG":
-            raise QgsProcessingException("Selected layers has unsupported format. Only GPKG layers are supported.")
+            raise QgsProcessingException("Selected layer not supported.")
 
         start = self.parameterAsInt(parameters, self.START_VERSION, context)
         if self.END_VERSION in parameters and parameters[self.END_VERSION] is not None:

--- a/Mergin/processing/algs/create_diff.py
+++ b/Mergin/processing/algs/create_diff.py
@@ -65,7 +65,7 @@ class CreateDiff(QgsProcessingAlgorithm):
         return 'Extracts changes made between two versions of the layer of the Mergin project to make it easier to revise changes.'
 
     def icon(self):
-        return QIcon(icon_path('icon.png', False))
+        return QIcon(icon_path('mm_icon_positive_no_padding.svg'))
 
     def __init__(self):
         super().__init__()

--- a/Mergin/processing/algs/create_diff.py
+++ b/Mergin/processing/algs/create_diff.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sqlite3
+import shutil
+
+from qgis.PyQt.QtGui import QIcon
+from qgis.core import (
+    QgsFeatureSink,
+    QgsProcessing,
+    QgsProcessingUtils,
+    QgsProcessingException,
+    QgsProcessingAlgorithm,
+    QgsProcessingContext,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterVectorLayer,
+    QgsProcessingParameterFeatureSink
+)
+
+from ..postprocessors import StylingPostProcessor
+
+from ...mergin.merginproject import MerginProject
+from ...mergin.utils import get_versions_with_file_changes
+
+from ...diff import (
+    parse_db_schema,
+    parse_diff,
+    get_table_name,
+    create_field_list,
+    diff_table_to_features
+)
+
+from ...utils import (
+    icon_path,
+    create_mergin_client,
+    check_mergin_subdirs,
+)
+
+
+class CreateDiff(QgsProcessingAlgorithm):
+
+    PROJECT_DIR = 'PROJECT_DIR'
+    LAYER = 'LAYER'
+    START_VERSION = 'START_VERSION'
+    END_VERSION = 'END_VERSION'
+    OUTPUT = 'OUTPUT'
+
+    def name(self):
+        return 'creatediff'
+
+    def displayName(self):
+        return 'Create diff'
+
+    def group(self):
+        return 'Tools'
+
+    def groupId(self):
+        return 'tools'
+
+    def tags(self):
+        return 'mergin,added,dropped,new,deleted,features,geometries,difference,delta,revised,original,version,compare'.split(',')
+
+    def shortHelpString(self):
+        return 'Extracts changes made between two versions of the layer of the Mergin project to make it easier to revise changes.'
+
+    def icon(self):
+        return QIcon(icon_path('icon.png', False))
+
+    def __init__(self):
+        super().__init__()
+
+    def createInstance(self):
+        return type(self)()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(QgsProcessingParameterFile(self.PROJECT_DIR, 'Project directory', QgsProcessingParameterFile.Folder))
+        self.addParameter(QgsProcessingParameterVectorLayer(self.LAYER, 'Input layer'))
+        self.addParameter(QgsProcessingParameterNumber(self.START_VERSION, 'Start version', QgsProcessingParameterNumber.Integer, 1, False, 1))
+        self.addParameter(QgsProcessingParameterNumber(self.END_VERSION, 'End version', QgsProcessingParameterNumber.Integer, None, True, 1))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, 'Diff layer'))
+
+    def processAlgorithm(self, parameters, context, feedback):
+        project_dir = self.parameterAsString(parameters, self.PROJECT_DIR, context)
+        layer = self.parameterAsVectorLayer(parameters, self.LAYER, context)
+
+        if not check_mergin_subdirs(project_dir):
+            raise QgsProcessingException("Selected directory does not contain a valid Mergin project.")
+
+        if not os.path.normpath(layer.source()).lower().startswith(os.path.normpath(project_dir)):
+            raise QgsProcessingException("Selected layer does not belong to the selected Mergin project.")
+
+        if layer.dataProvider().storageType() != "GPKG":
+            raise QgsProcessingException("Selected layers has unsupported format. Only GPKG layers are supported.")
+
+        start = self.parameterAsInt(parameters, self.START_VERSION, context)
+        if self.END_VERSION in parameters and parameters[self.END_VERSION] is not None:
+            end = self.parameterAsInt(parameters, self.END_VERSION, context)
+        else:
+            end = ''
+
+        table_name = get_table_name(layer)
+        layer_path = layer.source().split("|")[0]
+        file_name = os.path.split(layer_path)[1]
+
+        mc = create_mergin_client()
+        mp = MerginProject(project_dir)
+
+        feedback.pushInfo("Downloading base file…")
+        base_file = QgsProcessingUtils.generateTempFilename(file_name)
+        mc.download_file(project_dir, file_name, base_file, f"v{end}" if end else None)
+        feedback.setProgress(10)
+
+        diff_file = QgsProcessingUtils.generateTempFilename(file_name + ".diff")
+        mc.get_file_diff(project_dir, file_name, diff_file, f"v{start}", f"v{end}" if end else None)
+        feedback.setProgress(20)
+
+        feedback.pushInfo("Parse schema…")
+        db_schema = parse_db_schema(base_file)
+        feedback.setProgress(25)
+
+        feedback.pushInfo("Create field list…")
+        fields, fields_mapping = create_field_list(db_schema[table_name])
+        (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context, fields, layer.wkbType(), layer.sourceCrs())
+
+        feedback.pushInfo("Parse diff…" + diff_file)
+        diff = parse_diff(diff_file)
+        feedback.setProgress(30)
+
+        if diff and table_name in diff.keys():
+            db_conn = None  # no ref. db
+            db_conn = sqlite3.connect(layer_path)
+            features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, fields_mapping, db_conn)
+            feedback.setProgress(40)
+
+            current = 40
+            step = 60.0 / len(features) if features else 0
+            for i, f in enumerate(features):
+                if feedback.isCanceled():
+                    break
+                sink.addFeature(f, QgsFeatureSink.FastInsert)
+                feedback.setProgress(int(i * step))
+
+        if context.willLoadLayerOnCompletion(dest_id):
+            context.layerToLoadOnCompletionDetails(dest_id).setPostProcessor(StylingPostProcessor.create(db_schema[table_name]))
+
+        return {self.OUTPUT: dest_id}

--- a/Mergin/processing/algs/create_diff.py
+++ b/Mergin/processing/algs/create_diff.py
@@ -123,7 +123,7 @@ class CreateDiff(QgsProcessingAlgorithm):
         fields, fields_mapping = create_field_list(db_schema[table_name])
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context, fields, layer.wkbType(), layer.sourceCrs())
 
-        feedback.pushInfo("Parse diff…" + diff_file)
+        feedback.pushInfo("Parse diff…")
         diff = parse_diff(diff_file)
         feedback.setProgress(30)
 

--- a/Mergin/processing/algs/extract_local_changes.py
+++ b/Mergin/processing/algs/extract_local_changes.py
@@ -15,6 +15,8 @@ from qgis.core import (
     QgsProcessingParameterFeatureSink
 )
 
+from ..postprocessors import StylingPostProcessor
+
 from ...mergin.merginproject import MerginProject
 
 from ...diff import (
@@ -116,5 +118,8 @@ class ExtractLocalChanges(QgsProcessingAlgorithm):
                     break
                 sink.addFeature(f, QgsFeatureSink.FastInsert)
                 feedback.setProgress(int(i * step))
+
+        if context.willLoadLayerOnCompletion(dest_id):
+            context.layerToLoadOnCompletionDetails(dest_id).setPostProcessor(StylingPostProcessor.create(db_schema[table_name]))
 
         return {self.OUTPUT: dest_id}

--- a/Mergin/processing/algs/extract_local_changes.py
+++ b/Mergin/processing/algs/extract_local_changes.py
@@ -83,7 +83,7 @@ class ExtractLocalChanges(QgsProcessingAlgorithm):
             raise QgsProcessingException("Selected layer does not belong to the selected Mergin project.")
 
         if layer.dataProvider().storageType() != "GPKG":
-            raise QgsProcessingException("Selected layers has unsupported format. Only GPKG layers are supported.")
+            raise QgsProcessingException("Selected layer not supported.")
 
         mp = MerginProject(project_dir)
 
@@ -92,7 +92,7 @@ class ExtractLocalChanges(QgsProcessingAlgorithm):
         feedback.setProgress(5)
 
         if diff_path is None:
-            raise QgsProcessingException("Failed to retrieve changes, as there is no base file for input layer.")
+            raise QgsProcessingException("Failed to get local changes.")
 
         table_name = get_table_name(layer)
 

--- a/Mergin/processing/algs/extract_local_changes.py
+++ b/Mergin/processing/algs/extract_local_changes.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sqlite3
+
+from qgis.PyQt.QtGui import QIcon
+from qgis.core import (
+    QgsFeatureSink,
+    QgsProcessing,
+    QgsProcessingException,
+    QgsProcessingAlgorithm,
+    QgsProcessingContext,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterVectorLayer,
+    QgsProcessingParameterFeatureSink
+)
+
+from ...mergin.merginproject import MerginProject
+
+from ...diff import (
+    get_local_changes,
+    parse_db_schema,
+    parse_diff,
+    get_table_name,
+    create_field_list,
+    diff_table_to_features
+)
+
+from ...utils import (
+    icon_path,
+    check_mergin_subdirs,
+)
+
+
+class ExtractLocalChanges(QgsProcessingAlgorithm):
+
+    PROJECT_DIR = 'PROJECT_DIR'
+    LAYER = 'LAYER'
+    OUTPUT = 'OUTPUT'
+
+    def name(self):
+        return 'extractlocalchanges'
+
+    def displayName(self):
+        return 'Extract local changes'
+
+    def group(self):
+        return 'Tools'
+
+    def groupId(self):
+        return 'tools'
+
+    def tags(self):
+        return 'mergin,added,dropped,new,deleted,features,geometries,difference,delta,revised,original,version,compare'.split(',')
+
+    def shortHelpString(self):
+        return 'Extracts local changes made in the specific layer of the Mergin project to make it easier to revise changes.'
+
+    def icon(self):
+        return QIcon(icon_path('icon.png', False))
+
+    def __init__(self):
+        super().__init__()
+
+    def createInstance(self):
+        return type(self)()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(QgsProcessingParameterFile(self.PROJECT_DIR, 'Project directory', QgsProcessingParameterFile.Folder))
+        self.addParameter(QgsProcessingParameterVectorLayer(self.LAYER, 'Input layer'))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, 'Local changes layer'))
+
+    def processAlgorithm(self, parameters, context, feedback):
+        project_dir = self.parameterAsString(parameters, self.PROJECT_DIR, context)
+        layer = self.parameterAsVectorLayer(parameters, self.LAYER, context)
+
+        if not check_mergin_subdirs(project_dir):
+            raise QgsProcessingException("Selected directory does not contain a valid Mergin project.")
+
+        if not os.path.normpath(layer.source()).lower().startswith(os.path.normpath(project_dir)):
+            raise QgsProcessingException("Selected layer does not belong to the selected Mergin project.")
+
+        if layer.dataProvider().storageType() != "GPKG":
+            raise QgsProcessingException("Selected layers has unsupported format. Only GPKG layers are supported.")
+
+        mp = MerginProject(project_dir)
+
+        layer_path = layer.source().split("|")[0]
+        diff_path = get_local_changes(layer_path, mp)
+        feedback.setProgress(5)
+
+        if diff_path is None:
+            raise QgsProcessingException("Failed to retrieve changes, as there is no base file for input layer.")
+
+        table_name = get_table_name(layer)
+
+        db_schema = parse_db_schema(layer_path)
+        feedback.setProgress(10)
+
+        fields, fields_mapping = create_field_list(db_schema[table_name])
+        (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context, fields, layer.wkbType(), layer.sourceCrs())
+
+        diff = parse_diff(diff_path)
+        feedback.setProgress(15)
+
+        if diff and table_name in diff.keys():
+            db_conn = None  # no ref. db
+            db_conn = sqlite3.connect(layer_path)
+            features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, fields_mapping, db_conn)
+            feedback.setProgress(20)
+
+            current = 20
+            step = 80.0 / len(features) if features else 0
+            for i, f in enumerate(features):
+                if feedback.isCanceled():
+                    break
+                sink.addFeature(f, QgsFeatureSink.FastInsert)
+                feedback.setProgress(int(i * step))
+
+        return {self.OUTPUT: dest_id}

--- a/Mergin/processing/algs/extract_local_changes.py
+++ b/Mergin/processing/algs/extract_local_changes.py
@@ -59,7 +59,7 @@ class ExtractLocalChanges(QgsProcessingAlgorithm):
         return 'Extracts local changes made in the specific layer of the Mergin project to make it easier to revise changes.'
 
     def icon(self):
-        return QIcon(icon_path('icon.png', False))
+        return QIcon(icon_path('mm_icon_positive_no_padding.svg'))
 
     def __init__(self):
         super().__init__()

--- a/Mergin/processing/postprocessors.py
+++ b/Mergin/processing/postprocessors.py
@@ -1,0 +1,21 @@
+from qgis.core import QgsProcessingLayerPostProcessorInterface
+
+from ..diff import style_diff_layer
+
+
+class StylingPostProcessor(QgsProcessingLayerPostProcessorInterface):
+    instance = None
+
+    def __init__(self, table_schema):
+        super().__init__()
+        self.table_schema = table_schema
+
+    def postProcessLayer(self, layer, context, feedback):
+        style_diff_layer(layer, self.table_schema)
+        layer.triggerRepaint()
+
+    # Hack to work around sip bug!
+    @staticmethod
+    def create(table_schema):
+        StylingPostProcessor.instance = StylingPostProcessor(table_schema)
+        return StylingPostProcessor.instance

--- a/Mergin/processing/provider.py
+++ b/Mergin/processing/provider.py
@@ -8,6 +8,7 @@ from qgis.core import QgsProcessingProvider
 
 from ..utils import icon_path
 from .algs.create_report import CreateReport
+from .algs.extract_local_changes import ExtractLocalChanges
 
 
 class MerginProvider(QgsProcessingProvider):
@@ -37,6 +38,7 @@ class MerginProvider(QgsProcessingProvider):
 
     def getAlgs(self):
         algs = [CreateReport(),
+                ExtractLocalChanges()
                ]
 
         return algs

--- a/Mergin/processing/provider.py
+++ b/Mergin/processing/provider.py
@@ -9,6 +9,7 @@ from qgis.core import QgsProcessingProvider
 from ..utils import icon_path
 from .algs.create_report import CreateReport
 from .algs.extract_local_changes import ExtractLocalChanges
+from .algs.create_diff import CreateDiff
 
 
 class MerginProvider(QgsProcessingProvider):
@@ -38,7 +39,8 @@ class MerginProvider(QgsProcessingProvider):
 
     def getAlgs(self):
         algs = [CreateReport(),
-                ExtractLocalChanges()
+                ExtractLocalChanges(),
+                CreateDiff()
                ]
 
         return algs

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -13,7 +13,7 @@ from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from qgis.gui import QgsGui
-from qgis.core import Qgis, QgsApplication, QgsProject, QgsMapLayer
+from qgis.core import Qgis, QgsApplication, QgsProject, QgsMapLayer, QgsMessageLog
 
 from .validation import MultipleLayersWarning, warning_display_string
 from .utils import is_versioned_file, icon_path

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -46,7 +46,8 @@ class ProjectStatusDialog(QDialog):
         # add sync button with AcceptRole. If dialog accepted we will start
         # sync, otherwise just close status dialog
         self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
-        self.btn_diff = QPushButton("View changes")
+        self.btn_diff = QPushButton("View Changes")
+        self.btn_diff.setIcon(QIcon(icon_path("file-diff.svg")))
         self.ui.buttonBox.addButton(self.btn_diff, QDialogButtonBox.ActionRole)
         self.btn_diff.clicked.connect(self.show_changes)
 
@@ -58,8 +59,8 @@ class ProjectStatusDialog(QDialog):
         self.treeStatus.setModel(self.model)
 
         self.check_any_changes(pull_changes, push_changes)
-        self.add_content(pull_changes, "Server changes", True)
-        self.add_content(push_changes, "Local changes", False, push_changes_summary)
+        self.add_content(pull_changes, "Server Changes", True)
+        self.add_content(push_changes, "Local Changes", False, push_changes_summary)
         self.treeStatus.expandAll()
         self.changes_summary = push_changes_summary
 

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -61,6 +61,7 @@ class ProjectStatusDialog(QDialog):
         self.add_content(pull_changes, "Server changes", True)
         self.add_content(push_changes, "Local changes", False, push_changes_summary)
         self.treeStatus.expandAll()
+        self.changes_summary = push_changes_summary
 
         if not self.validation_results:
             self.ui.lblWarnings.hide()
@@ -193,6 +194,10 @@ class ProjectStatusDialog(QDialog):
         self.txtWarnings.setHtml(''.join(html))
 
     def show_changes(self):
+        if not self.changes_summary:
+            self.ui.messageBar.pushMessage("Mergin", "No changes found in the project layers.", Qgis.Info)
+            return
+
         self.close()
         dlg_diff_viewer = DiffViewerDialog()
         dlg_diff_viewer.show()

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -15,13 +15,9 @@ from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem, QIcon
 from qgis.gui import QgsGui
 from qgis.core import Qgis, QgsApplication, QgsProject, QgsMapLayer, QgsMessageLog
 
+from .diff_dialog import DiffViewerDialog
 from .validation import MultipleLayersWarning, warning_display_string
 from .utils import is_versioned_file, icon_path
-from .diff import (
-    make_local_changes_layer,
-    add_diff_layer_to_canvas,
-    diff_layers_list
-)
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ui', 'ui_status_dialog.ui')
 
@@ -50,8 +46,6 @@ class ProjectStatusDialog(QDialog):
         # add sync button with AcceptRole. If dialog accepted we will start
         # sync, otherwise just close status dialog
         self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
-        # add sync button with AcceptRole. If dialog accepted we will start
-        # sync, otherwise just close status dialog
         self.btn_diff = QPushButton("View changes")
         self.ui.buttonBox.addButton(self.btn_diff, QDialogButtonBox.ActionRole)
         self.btn_diff.clicked.connect(self.show_changes)
@@ -199,22 +193,7 @@ class ProjectStatusDialog(QDialog):
         self.txtWarnings.setHtml(''.join(html))
 
     def show_changes(self):
-        if self.mp is None:
-            self.mp = MerginProject(QgsProject.instance().homePath())
-
-        for layer in QgsProject.instance().mapLayers().values():
-            if layer.type() != QgsMapLayer.VectorLayer:
-                continue
-
-            if layer.dataProvider().storageType() != "GPKG":
-                QgsMessageLog.logMessage(f"Layer {layer.name()} is not supported.", "Mergin")
-                continue
-
-            vl, msg = make_local_changes_layer(self.mp, layer)
-            if vl is None:
-                QgsMessageLog.logMessage(msg, "Mergin")
-                continue
-            add_diff_layer_to_canvas(vl)
-            diff_layers_list.append(vl.id())
-
         self.close()
+        dlg_diff_viewer = DiffViewerDialog()
+        dlg_diff_viewer.show()
+        dlg_diff_viewer.exec_()

--- a/Mergin/project_status_dialog.py
+++ b/Mergin/project_status_dialog.py
@@ -46,10 +46,9 @@ class ProjectStatusDialog(QDialog):
         # add sync button with AcceptRole. If dialog accepted we will start
         # sync, otherwise just close status dialog
         self.ui.buttonBox.addButton(self.btn_sync, QDialogButtonBox.AcceptRole)
-        self.btn_diff = QPushButton("View Changes")
-        self.btn_diff.setIcon(QIcon(icon_path("file-diff.svg")))
-        self.ui.buttonBox.addButton(self.btn_diff, QDialogButtonBox.ActionRole)
-        self.btn_diff.clicked.connect(self.show_changes)
+
+        self.btn_view_changes.setIcon(QIcon(icon_path("file-diff.svg")))
+        self.btn_view_changes.clicked.connect(self.show_changes)
 
         self.validation_results = validation_results
         self.mp = mergin_project

--- a/Mergin/ui/ui_diff_viewer_dialog.ui
+++ b/Mergin/ui/ui_diff_viewer_dialog.ui
@@ -14,7 +14,17 @@
    <string>Changes Viewer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0" colspan="3">
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTabBar" name="tab_bar" native="true"/>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -23,23 +33,16 @@
      <widget class="QgsAttributeTableView" name="attribute_table"/>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="project_layers_checkbox">
-     <property name="text">
-      <string>Show also project layers</string>
+   <item row="1" column="0" colspan="2">
+    <widget class="QToolBar" name="toolbar">
+     <property name="iconSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
      </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" rowspan="2" colspan="3">
-    <widget class="QTabBar" name="tab_bar" native="true"/>
-   </item>
-   <item row="4" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+     <property name="floatable">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/Mergin/ui/ui_diff_viewer_dialog.ui
+++ b/Mergin/ui/ui_diff_viewer_dialog.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>556</width>
+    <height>408</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Diff viewer</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QgsMapLayerComboBox" name="diff_layer_cbo"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QToolButton" name="add_to_project_btn">
+     <property name="toolTip">
+      <string>Add diff layer to project</string>
+     </property>
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QCheckBox" name="project_layers_checkbox">
+     <property name="text">
+      <string>Show also project layers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QgsMapCanvas" name="map_canvas"/>
+     <widget class="QgsAttributeTableView" name="attribute_table"/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsMapCanvas</class>
+   <extends>QGraphicsView</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsAttributeTableView</class>
+   <extends>QTableView</extends>
+   <header>qgsattributetableview.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Mergin/ui/ui_diff_viewer_dialog.ui
+++ b/Mergin/ui/ui_diff_viewer_dialog.ui
@@ -7,40 +7,37 @@
     <x>0</x>
     <y>0</y>
     <width>556</width>
-    <height>408</height>
+    <height>541</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Diff viewer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QgsMapLayerComboBox" name="diff_layer_cbo"/>
-   </item>
-   <item row="0" column="1">
-    <widget class="QToolButton" name="add_to_project_btn">
-     <property name="toolTip">
-      <string>Add diff layer to project</string>
-     </property>
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QCheckBox" name="project_layers_checkbox">
-     <property name="text">
-      <string>Show also project layers</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
+   <item row="3" column="0" colspan="3">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <widget class="QgsMapCanvas" name="map_canvas"/>
      <widget class="QgsAttributeTableView" name="attribute_table"/>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="project_layers_checkbox">
+     <property name="text">
+      <string>Show also project layers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" rowspan="2" colspan="3">
+    <widget class="QTabBar" name="tab_bar" native="true"/>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
     </widget>
    </item>
   </layout>
@@ -53,16 +50,50 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgis.gui</header>
-  </customwidget>
-  <customwidget>
    <class>QgsAttributeTableView</class>
    <extends>QTableView</extends>
    <header>qgsattributetableview.h</header>
   </customwidget>
+  <customwidget>
+   <class>QTabBar</class>
+   <extends>QWidget</extends>
+   <header>qgis.PyQt.QtWidgets</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>363</x>
+     <y>519</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>277</x>
+     <y>270</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>363</x>
+     <y>519</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>277</x>
+     <y>270</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Mergin/ui/ui_diff_viewer_dialog.ui
+++ b/Mergin/ui/ui_diff_viewer_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Diff viewer</string>
+   <string>Changes Viewer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="3" column="0" colspan="3">
@@ -27,6 +27,9 @@
     <widget class="QCheckBox" name="project_layers_checkbox">
      <property name="text">
       <string>Show also project layers</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/Mergin/ui/ui_status_dialog.ui
+++ b/Mergin/ui/ui_status_dialog.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Project status</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
     <widget class="QgsMessageBar" name="messageBar">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -24,7 +24,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0" colspan="2">
     <widget class="QTreeView" name="treeStatus">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
@@ -34,14 +34,14 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QLabel" name="lblWarnings">
      <property name="text">
       <string>Warnings</string>
      </property>
     </widget>
    </item>
-   <item>
+   <item row="3" column="0" colspan="2">
     <widget class="QTextBrowser" name="txtWarnings">
      <property name="readOnly">
       <bool>true</bool>
@@ -54,7 +54,14 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0">
+    <widget class="QPushButton" name="btn_view_changes">
+     <property name="text">
+      <string>View Changes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Add an action "Show local changes" to the layer context menu toolbar button to open a "Diff viewer" dialog where one can examine local changes made in the project
![зображення](https://user-images.githubusercontent.com/776954/170030483-5d099825-1024-4a55-81ff-a09c351148dc.png)
If there are no changes in the project, a message bar will be shown, telling that there are no changes which can be visualised.
The "Changes Viewerer" dialog provides a tab-based UI, where each tab represents a local layer with changes. Changes in the layer will be shown on canvas and in the table form (splitted with a splitter).
![зображення](https://user-images.githubusercontent.com/776954/171412514-f9c7a67e-5709-4271-bbbf-75bd68e4e4ab.png)
Toolbar buttons allow user:
- toggle display of project layers (on by default)
- zoom to full extent of the changes layer
- zoom to selected features of the changes layer
- add currently displayed or all changes layers to project

All changes layers have styling applied and conditional formatting of the attribute table, to make it easier to see which values/features were updated/deleted/inserted.
![зображення](https://user-images.githubusercontent.com/776954/166923667-a9170e66-4cd2-4fac-b9ec-af70b444228e.png)
![зображення](https://user-images.githubusercontent.com/776954/166923942-b6a6337d-6b0e-4ee5-b6f7-3b2cfd284cbf.png)

A new button "View Changes" were added to the Sync Project dialog. Clicking on that button will close Sync Project dialog and open Changes Viewer.
![зображення](https://user-images.githubusercontent.com/776954/169812845-85c417a2-45ca-4ea4-8e9c-a157f89767b4.png)

Also add two new Processing tools: one for generating layer containing local changes and another one for generating layer containing changes between two versions of the layer.